### PR TITLE
Fixes #67 - corrects alert box position

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -405,6 +405,7 @@ fade-out
     margin-left:-250px;
     left:50%;
     position:absolute;
+    z-index: 99997;
 }
 
 #messages .alert

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,9 +38,9 @@
             </section>
         </header>
     </section>
+        <%= render 'layouts/messages' %>
 
     <section id="main-content">
-        <%= render 'layouts/messages' %>
         <main>
                 <%= yield %>
         </main>


### PR DESCRIPTION
Alert box was being covered by header, this moves the alert box outside
of the content area and places it between the header and the main
content area. It is still an <aside> do to being tangential content to
the whole page.
