### PR TITLE
Update organization model to match CIP data

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   helper_method :user_signed_in?
   helper_method :correct_user?
+  helper :format_phone
 
   private
     def current_user

--- a/app/helpers/format_phone_helper.rb
+++ b/app/helpers/format_phone_helper.rb
@@ -1,0 +1,7 @@
+module FormatPhoneHelper
+	# Format phone number as (XXX) XXX-XXXX
+	def format_phone(number)
+	  result = number.gsub(/[^\d]/, '')
+	  "(#{result[0..2]}) #{result[3..5]}-#{result[6..10]}"
+	end
+end

--- a/app/views/organizations/show.html.haml
+++ b/app/views/organizations/show.html.haml
@@ -11,37 +11,38 @@
 						%h1.name
 							= @org.name
 					
-					- if @org.address.present? || @org.phone_format.present? || @org.url.present?
+					- if @org.street_address.present? || @org.phones.present? || @org.urls.present?
 						%section.contact-box
 							%h1 
 								%span Contact
 
-							- if @org.address.present?
+							- if @org.street_address.present?
 								%p.address
 									%span{"data-icon"=>"✉" , :class=>"ohana-icon"}
 									%span
 										= @org.street_address 
 										%br 
-										= @org.city+","
-										= @org.state
-										%br
-										= @org.zipcode
+										= "#{@org.city}, #{@org.state} #{@org.zipcode}"
 							
-							- if @org.phone_format.present?
+							- if @org.phones.present?
 								%p.phone
 									%span{"data-icon"=>"☎" , :class=>"ohana-icon"}
 									%span
-										= @org.phone_format
+									- @org.phones.each do |hash|
+										= "#{format_phone(hash["number"])} #{hash["phone_hours"]}"	
+										%br							
 
-							- if @org.url.present?
+							- if @org.urls.present?
 								%p.url
-									%a{:href=>@org.url,:target=>"_blank"}
+								- @org.urls.each do |url|
+									%a{:href=>url,:target=>"_blank"}
 										%span{"data-icon"=>"🔗" , :class=>"external-link ohana-icon"}
-										Visit Website 
+										= url
+										%br
 
-							- if @org.email.present?
+							- if @org.emails.present?
 								%p.email
-									= @org.email
+									= @org.emails.join(", ")
 
 					- if @org.schedule.present?
 						%section.payment-box

--- a/data/smc_farmers_markets.json
+++ b/data/smc_farmers_markets.json
@@ -1,7 +1,9 @@
 {
   "25th Avenue Farmers' Market": {
     "name": "25th Avenue Farmers' Market",
-    "url": "http://www.pcfma.com/market_home.php?market_id=40",
+    "urls": [
+      "http://www.pcfma.com/market_home.php?market_id=40"
+    ],
     "street_address": "194 W 25th Avenue",
     "city": "San Mateo",
     "state": "California",
@@ -39,7 +41,9 @@
   },
   "Belmont Farmers' Market": {
     "name": "Belmont Farmers' Market",
-    "url": "http://www.pcfma.com/market_home.php?market_id=2",
+    "urls": [
+      "http://www.pcfma.com/market_home.php?market_id=2"
+    ],
     "street_address": "1201 El Camino Real",
     "city": "Belmont",
     "state": "California",
@@ -80,7 +84,9 @@
   },
   "Burlingame Fresh Market Farmers Market": {
     "name": "Burlingame Fresh Market Farmers Market",
-    "url": "http://www.burlingamechamber.org",
+    "urls": [
+      "http://www.burlingamechamber.org"
+    ],
     "street_address": "Howard Ave. & Park",
     "city": "Burlingame",
     "state": "California",
@@ -103,7 +109,9 @@
   },
   "Coastside Farmers' Market in Half Moon Bay": {
     "name": "Coastside Farmers' Market in Half Moon Bay",
-    "url": "http://www.coastsidefarmersmarket.org",
+    "urls": [
+      "http://www.coastsidefarmersmarket.org"
+    ],
     "street_address": "225 Cabrillo Hwy S",
     "city": "Half Moon Bay",
     "state": "California",
@@ -149,7 +157,9 @@
   },
   "Coastside Farmers' Market of Pacifca": {
     "name": "Coastside Farmers' Market of Pacifca",
-    "url": "http://www.coastsidefarmersmarket.org/",
+    "urls": [
+      "http://www.coastsidefarmersmarket.org/"
+    ],
     "street_address": "400 Old County Road",
     "city": "Pacifica",
     "state": "California",
@@ -193,7 +203,9 @@
   },
   "College of San Mateo Certified Farmers' Market": {
     "name": "College of San Mateo Certified Farmers' Market",
-    "url": "http://pcfma.com/market_home.php?market_id=15",
+    "urls": [
+      "http://pcfma.com/market_home.php?market_id=15"
+    ],
     "street_address": "1700 W. Hillsdale Blvd.",
     "city": "San Mateo",
     "state": "California",
@@ -234,7 +246,9 @@
   },
   "Daly City Farmers' Market at Serramonte Center": {
     "name": "Daly City Farmers' Market at Serramonte Center",
-    "url": "http://cafarmersmkts.com/markets/category/daly-city",
+    "urls": [
+      "http://cafarmersmkts.com/markets/category/daly-city"
+    ],
     "street_address": "133 Serramonte Center",
     "city": "Daly City",
     "state": "California",
@@ -271,7 +285,9 @@
   },
   "East Palo Alto Community Farmers Market": {
     "name": "East Palo Alto Community Farmers Market",
-    "url": "http://www.collectiveroots.org",
+    "urls": [
+      "http://www.collectiveroots.org"
+    ],
     "street_address": "1798-A Bay Road",
     "city": "East Palo Alto",
     "state": "California",
@@ -301,11 +317,13 @@
   },
   "Hot Harvest Nights San Carlos Farmers' Market": {
     "name": "Hot Harvest Nights San Carlos Farmers' Market",
-    "url": "https://www.sancarloschamber.org/textpages/farmers_market.aspx",
+    "urls": [
+      "https://www.sancarloschamber.org/textpages/farmers_market.aspx"
+    ],
     "street_address": "700 Block, Laurel Street",
     "city": "San Carlos",
     "state": "California",
-    "zipcode": "94070",
+    "zipcode": null,
     "schedule": "May 2 - September 12 Thursday 4:00 PM to 8:00 PM",
     "longitude": "-122.26",
     "latitude": "37.5049",
@@ -330,7 +348,9 @@
   },
   "Kaiser Permanente Redwood City Farmers' Market": {
     "name": "Kaiser Permanente Redwood City Farmers' Market",
-    "url": "http://www.pcfma.com/market_home.php?market_id=39",
+    "urls": [
+      "http://www.pcfma.com/market_home.php?market_id=39"
+    ],
     "street_address": "1150 Veterans Blvd.",
     "city": "Redwood City",
     "state": "California",
@@ -359,7 +379,9 @@
   },
   "Kaiser Permanente South San Francisco Farmers' Market": {
     "name": "Kaiser Permanente South San Francisco Farmers' Market",
-    "url": "http://www.pcfma.com/market_home.php?market_id=26",
+    "urls": [
+      "http://www.pcfma.com/market_home.php?market_id=26"
+    ],
     "street_address": "1200 El Camino Real",
     "city": "South San Francisco",
     "state": "California",
@@ -391,7 +413,9 @@
   },
   "Los Altos Farmers Market": {
     "name": "Los Altos Farmers Market",
-    "url": "http://cafarmersmkts.com/markets/category/los-altos-farmers-market",
+    "urls": [
+      "http://cafarmersmkts.com/markets/category/los-altos-farmers-market"
+    ],
     "street_address": "State Street and Second Street",
     "city": "Los Altos",
     "state": "California",
@@ -429,7 +453,9 @@
   },
   "Menlo Park Farmers' Market": {
     "name": "Menlo Park Farmers' Market",
-    "url": "http://localharvest.org",
+    "urls": [
+      "http://localharvest.org"
+    ],
     "street_address": "Chestnut & Menlo Avenues",
     "city": "Menlo Park",
     "state": "California",
@@ -469,7 +495,9 @@
   },
   "Millbrae Farmers Market": {
     "name": "Millbrae Farmers Market",
-    "url": "http://www.millbrae.com",
+    "urls": [
+      "http://www.millbrae.com"
+    ],
     "street_address": "200 Broadway",
     "city": "Millbrae",
     "state": "California",
@@ -504,7 +532,9 @@
   },
   "Pescadero Grown": {
     "name": "Pescadero Grown",
-    "url": "http://Www.pescaderogrown.org",
+    "urls": [
+      "http://Www.pescaderogrown.org"
+    ],
     "street_address": "8875 La Honda Road",
     "city": "La Honda",
     "state": "California",
@@ -544,7 +574,9 @@
   },
   "PJCC Farmers' Market at Foster City": {
     "name": "PJCC Farmers' Market at Foster City",
-    "url": "http://www.urbantable.org",
+    "urls": [
+      "http://www.urbantable.org"
+    ],
     "street_address": "800 Foster City Blvd.",
     "city": "Foster City",
     "state": "California",
@@ -575,7 +607,9 @@
   },
   "Redwood City Kiwanis Farmers Market": {
     "name": "Redwood City Kiwanis Farmers Market",
-    "url": "http://www.rwcfm.org",
+    "urls": [
+      "http://www.rwcfm.org"
+    ],
     "street_address": "850 Winslow Street",
     "city": "Redwood City",
     "state": "California",
@@ -609,7 +643,9 @@
   },
   "San Mateo Farmers' Market": {
     "name": "San Mateo Farmers' Market",
-    "url": "http://www.pcfma.com/sanmateo",
+    "urls": [
+      "http://www.pcfma.com/sanmateo"
+    ],
     "street_address": "1700 West Hillsdale Boulevard",
     "city": "San Mateo",
     "state": "California",
@@ -656,7 +692,9 @@
   },
   "Saratoga Farmers' Market": {
     "name": "Saratoga Farmers' Market",
-    "url": "http://cafarmersmkts.com/markets/category/saratoga",
+    "urls": [
+      "http://cafarmersmkts.com/markets/category/saratoga"
+    ],
     "street_address": "West Valley College, 14000 Fruitvale Avenue",
     "city": "Saratoga",
     "state": "California",
@@ -698,7 +736,9 @@
   },
   "South San Francisco Farmers Market": {
     "name": "South San Francisco Farmers Market",
-    "url": "http://pcfma.com/market_home.php?market_id=37",
+    "urls": [
+      "http://pcfma.com/market_home.php?market_id=37"
+    ],
     "street_address": "748 Tennis Dr",
     "city": "South San Francisco",
     "state": "California",
@@ -733,11 +773,13 @@
   },
   "Urban Table Certified Farmer's Market": {
     "name": "Urban Table Certified Farmer's Market",
-    "url": "https://www.facebook.com/UrbanMarketSanMateo",
+    "urls": [
+      "https://www.facebook.com/UrbanMarketSanMateo"
+    ],
     "street_address": "385 1st Avenue",
     "city": "San Mateo",
     "state": "California",
-    "zipcode": "94401",
+    "zipcode": null,
     "schedule": "April 1 - October 28 Monday 5:00 PM to 8:30 PM",
     "longitude": "-122.324",
     "latitude": "37.5663",

--- a/lib/tasks/load_data.rake
+++ b/lib/tasks/load_data.rake
@@ -8,7 +8,7 @@ task :load_data => :environment do
   files = ['data/libraries_data.json', 'data/smc_farmers_markets.json']
   files.each do |file|
     puts "Processing #{file}"
-    data = JSON.parse(File.open(file,'r').read).values
+    data = JSON.parse(File.read(file)).values
     data.each do |json|
       Organization.create! do |db|
         json.keys.each do |field|

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
     coordinates [-122.274369, 37.317983]
     keywords ["market"]
     schedule "May - November Tuesday 3:00 PM to 7:00 PM"
-    url "http://Www.pescaderogrown.org"
+    urls ["http://Www.pescaderogrown.org"]
     payments_accepted ["Credit", "WIC", "SFMNP", "SNAP"]
     products_sold ["Cheese", "Flowers", "Eggs", "Seafood", "Herbs", "Vegetables", "Jams", "Meat", "Nursery", "Plants", "Poultry"]
   end

--- a/spec/features/farmers_market_spec.rb
+++ b/spec/features/farmers_market_spec.rb
@@ -8,7 +8,7 @@ feature 'Visitor views the details page of a farmers market' do
     expect(page).to have_content("This market accepts Credit, WIC, SFMNP, SNAP")
     expect(page).to have_content("Products sold: Cheese")
     expect(page).to have_content("May - November Tuesday 3:00 PM to 7:00 PM")
-    page.should have_link("Website", :href => "http://Www.pescaderogrown.org") 
+    page.should have_link("http://Www.pescaderogrown.org", :href => "http://Www.pescaderogrown.org") 
   end
 
   @javascript

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -49,25 +49,25 @@ describe Organization do
 	  	it { should_not be_valid }
 		end
 
-		context "without a street address" do
-	  	subject { build(:organization, street_address: nil) }
-	  	it { should_not be_valid }
-		end
+		# context "without a street address" do
+	 #  	subject { build(:organization, street_address: nil) }
+	 #  	it { should_not be_valid }
+		# end
 
-		context "without a city" do
-	  	subject { build(:organization, city: nil) }
-	  	it { should_not be_valid }
-		end
+		# context "without a city" do
+	 #  	subject { build(:organization, city: nil) }
+	 #  	it { should_not be_valid }
+		# end
 
-		context "without a state" do
-	  	subject { build(:organization, state: nil) }
-	  	it { should_not be_valid }
-		end
+		# context "without a state" do
+	 #  	subject { build(:organization, state: nil) }
+	 #  	it { should_not be_valid }
+		# end
 
-		context "without a zipcode" do
-	  	subject { build(:organization, zipcode: nil) }
-	  	it { should_not be_valid }
-		end
+		# context "without a zipcode" do
+	 #  	subject { build(:organization, zipcode: nil) }
+	 #  	it { should_not be_valid }
+		# end
 
 		context "with a zipcode less than 5 characters" do
 	  	subject { build(:organization, zipcode: "1234") }
@@ -100,32 +100,32 @@ describe Organization do
 		end
 
 		context "with URL containing 3 slashes" do
-	  	subject { build(:organization, url: "http:///codeforamerica.org") }
+	  	subject { build(:organization, urls: ["http:///codeforamerica.org"]) }
 	  	it { should_not be_valid }
 		end
 
 		context "with URL missing a period" do
-	  	subject { build(:organization, url: "http://codeforamericaorg") }
+	  	subject { build(:organization, urls: ["http://codeforamericaorg"]) }
 	  	it { should_not be_valid }
 		end
 
 		context "URL with wwww" do
-	  	subject { build(:organization, url: "http://wwww.codeforamerica.org") }
+	  	subject { build(:organization, urls: ["http://wwww.codeforamerica.org"]) }
 	  	it { should be_valid }
 		end
 
 		context "non-US URL" do
-	  	subject { build(:organization, url: "http://www.colouredlines.com.au") }
+	  	subject { build(:organization, urls: ["http://www.colouredlines.com.au"]) }
 	  	it { should be_valid }
 		end
 
 		context "email without period" do
-	  	subject { build(:organization, email: "moncef@blahcom") }
+	  	subject { build(:organization, emails: ["moncef@blahcom"]) }
 	  	it { should_not be_valid }
 		end
 
 		context "email without @" do
-	  	subject { build(:organization, email: "moncef.blahcom") }
+	  	subject { build(:organization, emails: ["moncef.blahcom"]) }
 	  	it { should_not be_valid }
 		end
 	end


### PR DESCRIPTION
Updated the tests to describe the changes we want to make.

Some organizations have multiple emails, URLs, faxes, and TTYs, so the field type has been changed to Array.

Some organizations don't have a constant physical location, so I removed the requirement that an address be present.

Because emails and URLs are now arrays, we can't use the validates_formatting_of gem, so I created Class methods to validate each email and URL in the array using the same regex from the validates_formatting_of gem.

I moved the phone formatting method to a helper and modified it to accept a phone number as a parameter. I also changed its name to reflect what it does.

I updated the "show" view to match the model changes.

I updated the farmers' markets json to put the url in an "urls" array.
