### PR TITLE
Fixes #89 - Fixes Firefox input textfield bug

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -847,10 +847,11 @@ fade-out
 
 #search-box.mini input
 {
-    height:0px;
+    height:16px;
     font-size: 14px;
     background:$white;
     margin-bottom:5px;
+    width:170px;
 }
 
 #search-box.mini input::-webkit-input-placeholder


### PR DESCRIPTION
Input height was not tall enough to show text in Firefox, this has been
corrected. Also, explicit width and height has been set on the input
fields to make them (more) consistent across browsers.
