### PR TITLE
Fixes #70 - centers (x) in alert box

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -453,8 +453,9 @@ fade-out
     height: 10px;
     width: 10px;
     display: inline-block;
-    line-height: 10px;
+    line-height: 9px;
     cursor:pointer;
+    text-align: center;
 }
 
 #messages .close:hover


### PR DESCRIPTION
The close (x) button in the alert box was not centered in Safari. This
fixes that issue.
