### PR TITLE
Fixes popup issue

### DIFF
--- a/app/assets/javascripts/module/popup-manager.js
+++ b/app/assets/javascripts/module/popup-manager.js
@@ -16,8 +16,14 @@ var module = (function (module) {
 			{
 				var popup = popups[p].firstElementChild;
 				var term = popups[p].lastElementChild;
-				popup.classList.add("hide");
-				term.addEventListener("mousedown", popupHandler, false);
+				if ((/\S/.test(popup.textContent)))
+				{
+					term.addEventListener("mousedown", popupHandler, false);
+				}
+				else
+				{
+					term.style.cursor = 'default';
+				}
 			}
 		}
 

--- a/app/views/component/organizations/detail/_body.html.haml
+++ b/app/views/component/organizations/detail/_body.html.haml
@@ -72,8 +72,8 @@
 									-@org.payments_accepted.sort.each do |payment|
 										%li
 											%span.popup-container
-												%span.popup
-													- dynamic_partial = 'components/popup/'+payment.downcase
+												%span.popup.hide
+													- dynamic_partial = 'component/popup/'+payment.downcase
 													= render :partial => "#{dynamic_partial}" rescue nil
 												%span.popup-term
 													= payment
@@ -81,8 +81,8 @@
 							%div.market-match
 								This market participates in 
 								%span.popup-container
-									%span.popup
-										= render :partial => 'components/popup/marketmatch' rescue nil
+									%span.popup.hide
+										= render :partial => 'component/popup/marketmatch' rescue nil
 									%span.popup-term
 										Market Match!
 


### PR DESCRIPTION
Popups were showing up as the details view was loading, but before the
JavaScript hid them. This commit hides them initially using CSS. It
also prevents any rollover/click behavior when a popup doesn't have an
content (meaning it's missing a partial with the same term name).
