### PR TITLE
Updates mapbox static map tile URL

### DIFF
--- a/app/helpers/detail_format_helper.rb
+++ b/app/helpers/detail_format_helper.rb
@@ -20,7 +20,7 @@ module DetailFormatHelper
   # @return [String] return static map URL if coordinates are present.
   def map_url(org)
     if org.coordinates.present?
-      "http://api.tiles.mapbox.com/v3/examples.map-4l7djmvo/pin-s("+
+      "http://api.tiles.mapbox.com/v3/examples.map-rlxntei0/pin-s("+
         "#{org.coordinates[0]},#{org.coordinates[1]})/#{org.coordinates[0]}"+
         ",#{org.coordinates[1]},15/400x300.png"
     end


### PR DESCRIPTION
Map tile was outdated. This updates the URL to a working map. This is a
temporary solution as this should really use a mapbox key for
retrieving maps. However, detail views a likely to replace static maps
with regular maps the can be zoomed, panned, etc.
