### PR TITLE
Fixes #194 - scrolls page to the top of on ajax results

### DIFF
--- a/app/assets/javascripts/module/search/ajax-search.js
+++ b/app/assets/javascripts/module/search/ajax-search.js
@@ -105,6 +105,7 @@ define(['app/loading-manager','util/ajax','util/util','result-view-manager'],
 
 		function _success(evt)
 		{
+			window.scrollTo(0,0); // scrolls page to the top of the page when ajax finishes
 			_ajaxCalled = true;
 			resultsContainer.innerHTML = evt.content;
 			resultViewManager.init();


### PR DESCRIPTION
When ajax loads part of the page, it's scrolled to the top of the page
to ensure the detail view is visible when results are clicked.
