### PR TITLE
Removes double request when viewing detail view directly

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -34,8 +34,11 @@ class OrganizationsController < ApplicationController
 
         perform_search_query(params)
 
-        # pick out particular detail being viewed
         @org = @orgs.find { |o| o['_id'] == params[:id] }
+
+        if @org.nil?
+          @org = Organization.get(params[:id]).content
+        end
       }
 
       # visit via ajax


### PR DESCRIPTION
When visiting an entry directly two requests were being made. This
commit makes it so only one request is performed in this case.
