### PR TITLE
Added protect_from_forgery back in application_controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery
 end


### PR DESCRIPTION
This was accidentally removed at some point. It's required for security purposes.
