### PR TITLE
Fixes no results map issue

### DIFF
--- a/app/assets/javascripts/search/map-view-manager.js
+++ b/app/assets/javascripts/search/map-view-manager.js
@@ -302,7 +302,8 @@ define(['util/util'],function(util) {
 			if (_tilesLoadedListener) google.maps.event.removeListener(_tilesLoadedListener);
 			_loadMarkers();
 			_tilesLoadedListener = google.maps.event.addListener(_map,"tilesloaded",_mapLoaded);
-			_map.fitBounds(_markerBounds);
+			if (_markersArray.length > 0)
+				_map.fitBounds(_markerBounds);
 		}
 
 	return {


### PR DESCRIPTION
When map had no results it was trying to fit to the bounds of the
markers. Since there aren't any when there are no results, the map was
throwing a JavaScript error. This fixes the issue by first checking
that markers exist before performing a fit to bounds operation on the
map.
