### PR TITLE
Fixes #253 - updates 2-1-1 text

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -997,7 +997,6 @@ sup
   #app-footer
   {
     position:relative;
-    padding:20px;
     text-align:center;
     background:$white;
     clear:both;
@@ -1005,11 +1004,18 @@ sup
 
     p#call-211
     {
+      text-align:center;
       font-size:16px;
+      letter-spacing: 1px;
+      color:$purple_darkest;
+      background:$yellow_light;
+      font-family:$san_serif_font;
+      padding:7px;
+      border-bottom:2px solid $blue_midtone;
+
       strong
       {
         font-weight:bold;
-        color:$yellow_darkest;
       }
     }
 
@@ -1019,7 +1025,6 @@ sup
       font-size:14px;
       font-family:$san_serif_font;
       color:$greyscale_midtone;
-      display:inline-block;
     }
 
     p span.cfaflag
@@ -1632,23 +1637,6 @@ main
         }
       }
 
-    }
-  }
-
-  p
-  {
-    text-align:center;
-    font-size:13px;
-    letter-spacing: 1px;
-    color:$purple_darkest;
-    background:$yellow_light;
-    font-family:$san_serif_font;
-    padding:7px;
-
-    strong
-    {
-      font-weight:bold;
-      @include inline-block();
     }
   }
 }

--- a/app/views/component/search/_category.html.haml
+++ b/app/views/component/search/_category.html.haml
@@ -9,6 +9,3 @@
     %ul
       - emergency_terms.each do |service|
         = render :partial => "home/category_links", :locals => { :service => service }
-    %p
-      NEED IMMEDIATE ASSISTANCE?
-      %strong DIAL 2-1-1

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -96,7 +96,7 @@
     </main>
 
     <footer id='app-footer'>
-      <p id='call-211'><strong>HELP!</strong> Have an immediate need and want to talk to someone? <strong>Dial 2-1-1</strong> and an operator will assist you.
+      <p id='call-211'>Need additional assistance and want to talk to someone? <strong>Dial 2-1-1</strong> and an operator will assist you.
       </p>
       <p>This website is a <a href='http://codeforamerica.org' target='_blank' title='Code for America'>Code for America</a> project <span class='cfaflag'></span> in partnership with the <a href='http://www.co.sanmateo.ca.us/portal/site/humanservices' target='_blank' title='San Mateo County Human Services agency'>San Mateo County Human Services Agency</a>
       </p>


### PR DESCRIPTION
Tones down 2-1-1 text and removes it from being associated with the
emergency boxes.

![screen shot 2013-09-19 at 1 27 29 am](https://f.cloud.github.com/assets/704760/1170732/37be2fa2-20ec-11e3-8a0e-047218fcdaa3.png)
