### PR TITLE
Use GA script from docs instead of analytics portal

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,14 +35,16 @@
     <%= csrf_meta_tags %>
     <%= yield(:head) %>
     <% if Rails.env.production? %>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      <script type="text/javascript">
+        var _gaq = _gaq || [];
+        _gaq.push(['_setAccount', 'UA-40905652-1']);
+        _gaq.push(['_trackPageview']);
 
-        ga('create', 'UA-40905652-1', 'herokuapp.com');
-        ga('send', 'pageview');
+        (function() {
+          var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+          ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+        })();
       </script>
     <% end %>
   </head>


### PR DESCRIPTION
Google's docs are not in sync with the actual portal. The tracking code snippet from the portal doesn't define "_gaq", so tracking hasn't been working since "_gaq" was not defined. I just noticed the error in the console.

I switched to the code provided in the docs, which does define "_gaq", so hopefully we'll start getting some tracking data now.
