### PR TITLE
Add key-based fragment caching to views

### DIFF
--- a/app/views/component/organizations/results/_body.html.haml
+++ b/app/views/component/organizations/results/_body.html.haml
@@ -23,16 +23,16 @@
       %p.message
         %strong Unfortunately, your search returned no results.
         %em If you have trouble finding what you're looking for, try searching with a single keyword or click a category of service below.
-
-    %section#category-box
-      %section
-        %ul
-          - taxonomy_terms.each do |service|
-            %li
-              %a{ :href => "/organizations?keyword=#{u service[:parent]}", :onClick => "_gaq.push(['_trackEvent', 'Home_Categories', 'Click', '#{service[:parent]}']);" }
-                = service[:parent]
-              %ul
-                - service[:children].each do |child|
-                  %li
-                    %a{ :href => "/organizations?keyword=#{u child}", :onClick => "_gaq.push(['_trackEvent', 'Home_Categories', 'Click', '#{child}']);" }
-                      = child
+    - cache ['taxonomy-list', *taxonomy_terms] do
+      %section#category-box
+        %section
+          %ul
+            - taxonomy_terms.each do |service|
+              %li
+                %a{ :href => "/organizations?keyword=#{u service[:parent]}", :onClick => "_gaq.push(['_trackEvent', 'Results_Categories', 'Click', '#{service[:parent]}']);" }
+                  = service[:parent]
+                %ul
+                  - service[:children].each do |child|
+                    %li
+                      %a{ :href => "/organizations?keyword=#{u child}", :onClick => "_gaq.push(['_trackEvent', 'Results_Categories', 'Click', '#{child}']);" }
+                        = child

--- a/app/views/component/search/_aside.html.haml
+++ b/app/views/component/search/_aside.html.haml
@@ -5,19 +5,19 @@
       %label{:for => "keyword"}
         I need...
       = search_field_tag :keyword, params[:keyword], :placeholder => "enter a keyword", :list => "search-keywords"
-
-      %datalist#search-keywords
-        - cip_keywords.each do |keyword|
-          %option{:value=>keyword}
+      - cache ['keywords-list', *cip_keywords] do
+        %datalist#search-keywords
+          - cip_keywords.each do |keyword|
+            %option{:value=>keyword}
 
     -# location search box input field appears below
     %section#location-search-box
       %label{:for => "location"}
         I am near...
       = search_field_tag :location, params[:location], :placeholder => "enter a location", :list => "search-locations"
-
-      %datalist#search-locations
-        - smc_cities.each do |city|
-          %option{:value=>city}
+      - cache ['cities-list', *smc_cities] do
+        %datalist#search-locations
+          - smc_cities.each do |city|
+            %option{:value=>city}
 
     = render :partial => 'component/search/options'

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -5,14 +5,10 @@
         %label{:for => "keyword"}
           I need...
         = search_field_tag :keyword, params[:keyword], :placeholder => "what are you looking for?", :list => "search-keywords"
-
-        %datalist#search-keywords
-          - cip_keywords.each do |keyword|
-            %option{:value=>keyword}
-
-        %datalist#search-locations
-          - smc_cities.each do |city|
-            %option{:value=>city}
+        - cache ['keywords-list', *cip_keywords] do
+          %datalist#search-keywords
+            - cip_keywords.each do |keyword|
+              %option{:value=>keyword}
 
       %button{:type=>'submit',:id=>'find-btn', :title=>"Search"}
         %span{"data-icon"=>"🔍" , :class=>"search-button ohana-icon"}

--- a/app/views/component/search/_category.html.haml
+++ b/app/views/component/search/_category.html.haml
@@ -1,11 +1,12 @@
 %section#category-box
   -# Category search terms that are displayed on the homepage
-  %section#general-services
-    %ul
-      - service_terms.each do |service|
-        = render :partial => "home/category_links", :locals => { :service => service }
-
-  %section#emergency-services
-    %ul
-      - emergency_terms.each do |service|
-        = render :partial => "home/category_links", :locals => { :service => service }
+  - cache ['service-list', *service_terms] do
+    %section#general-services
+      %ul
+        - service_terms.each do |service|
+          = render :partial => "home/category_links", :locals => { :service => service }
+  - cache ['emergency-list', *emergency_terms] do
+    %section#emergency-services
+      %ul
+        - emergency_terms.each do |service|
+          = render :partial => "home/category_links", :locals => { :service => service }


### PR DESCRIPTION
The datalist and categories that are read from arrays each time a view is accessed should be cached. With key-based fragment caching, those items will be pulled from cache, and if the array changes, the cache will auto-expire and cache the new version until the next time it is changed.
