### PR TITLE
Set canonical URL for details page.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,19 @@ module ApplicationHelper
 		end
 	end
 
+  # Since this app includes various parameters in the URL when linking to a
+  # location's details page, we can end up with many URLs that display the
+  # same content. To gain more control over which URL appears in Google search
+  # results, we can use the <link> element with the "rel=canonical" attribute.
+
+  # This helper allows us to set the canonical URL for the details page in the
+  # view. See app/views/organizations/show.html.haml
+  #
+  # More info: https://support.google.com/webmasters/answer/139066
+  def canonical(url)
+    content_for(:canonical, tag(:link, :rel => :canonical, :href => url)) if url
+  end
+
   # Top level services and their children categories.
   # Displayed on the home page and on the details page
   # when no search results are found.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
     <%= requirejs_include_tag("routes/#{controller_name}/#{action_name}").gsub( "/assets/routes/#{controller_name}/#{action_name}", "routes/#{controller_name}/#{action_name}").html_safe %>
     <%= csrf_meta_tags %>
     <%= yield(:head) %>
+    <%= yield :canonical %>
     <% if Rails.env.production? %>
       <script type="text/javascript">
         var _gaq = _gaq || [];

--- a/app/views/organizations/show.html.haml
+++ b/app/views/organizations/show.html.haml
@@ -1,4 +1,5 @@
 - title @org.name
+- canonical("#{organizations_url}/#{@org.id}")
 = render 'component/search/aside'
 %section#results-container
 	= render 'component/organizations/detail/body'


### PR DESCRIPTION
Since this app includes various parameters in the URL when linking to a
location's details page, we can end up with many URLs that display the
same content. To gain more control over which URL appears in Google search
results, we can use the <link> element with the "rel=canonical" attribute in the <head> section of the page.
