### PR TITLE
Fixes cookie persistence

### DIFF
--- a/app/assets/javascripts/app/google-translate-manager.js
+++ b/app/assets/javascripts/app/google-translate-manager.js
@@ -9,8 +9,21 @@ define(['util/util'],function(util) {
 		// PUBLIC METHODS
 		function init()
 		{
+      _deleteTranslateCookies();
       _checkForGoog();
 		}
+
+    function _deleteTranslateCookies() {
+        var cookies = document.cookie.split(";");
+
+        for (var i = 0; i < cookies.length; i++) {
+          var cookie = cookies[i];
+          var eqPos = cookie.indexOf("=");
+          var name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+          if (name == "googtrans")
+            document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
+        }
+    }
 
     function _checkForGoog()
     {

--- a/app/assets/javascripts/app/popup-manager.js
+++ b/app/assets/javascripts/app/popup-manager.js
@@ -10,8 +10,9 @@ define(['util/util','app/feedback-form-manager'/*,'enquire'*/],function(util,fee
 		// PUBLIC METHODS
 		function init()
 		{
-			if (!util.isURLParamPresent("translate"))
-			{
+			var translate = util.getQueryParams()['translate'];
+      if (!translate || translate != 'en')
+      {
 				_addPopups();
 				feedback.init();
 				// try/catch added to ignore IE errors

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 	# Sets cookie with english -> [translate] language code value.
 	# Deletes cookie if [translate] is english
 	def set_translation_cookie
+
 		if params[:translate].present?
 
 			# List of used language code values are as follows:
@@ -25,26 +26,19 @@ class ApplicationController < ActionController::Base
 			# 'tamil'=>'ta','telugu'=>'te','thai'=>'th','turkish'=>'tr','ukrainian'=>'uk',
 			# 'urdu'=>'ur','vietnamese'=>'vi','yiddish'=>'yi'}
 
-		  lang = params[:translate]
+		  @current_lang = params[:translate]
 
-		  if lang == 'en'
-		  	cookies.delete :googtrans
-		  else
-		  	cookies[:googtrans] = "/en/#{lang}"
-				#headers['Set-Cookie'] = "googtrans=/en/#{lang};domain=.herokuapp.com"
-				#headers['Set-Cookie'] = "googtrans=/en/#{lang};domain=ohana-staging.herokuapp.com"
-				#headers['Set-Cookie'] = "googtrans=/en/#{lang};domain=.ohana-staging.herokuapp.com"
-		  end
+			# clear all translation cookies
+			cookies.delete(:googtrans,:domain=>".#{ENV['TRANSLATE_URL']}")
+			cookies.delete(:googtrans,:domain=>"www.#{ENV['TRANSLATE_URL']}")
+			cookies.delete(:googtrans,:domain=>".www.#{ENV['TRANSLATE_URL']}")
+			cookies.delete(:googtrans,:domain=>:all)
+			headers['Set-Cookie'] = "googtrans=/en/#{@current_lang};domain=.www#{ENV['TRANSLATE_URL']}"
 
 		else
-			lang = 'en'
+			@current_lang = 'en'
 		end
 
-		if cookies[:googtrans].present?
-			@current_lang = cookies[:googtrans][4..cookies[:googtrans].length]
-		else
-			@current_lang = lang
-		end
 	end
 
 end


### PR DESCRIPTION
Google Translate cookies were not being overwritten or removed properly
on production. This commit deletes all Google Translate cookies before
setting cookie value.
