### PR TITLE
Adds check for current cookie value

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
 			cookies.delete(:googtrans,:domain=>:all)
 			headers['Set-Cookie'] = "googtrans=/en/#{@current_lang};domain=.www.#{ENV['TRANSLATE_URL']}"
 
-		elsif cookies['googtrans'].present?
+		elsif cookies[:googtrans].present?
 			@current_lang = cookies[:googtrans].split('/')[-1]
 		else
 			@current_lang = 'en'


### PR DESCRIPTION
Language selection was not remembered when translate parameter was not
present. This checks the cookie value if the translate URL parameter is
missing.
