### PR TITLE
Hide datalist ie

### DIFF
--- a/app/views/component/search/_options.html.haml
+++ b/app/views/component/search/_options.html.haml
@@ -3,11 +3,13 @@
   = render :partial => "component/search/filter", :locals => {:field=>"location", :legend=>"Near Address",:field_value=>params[:location], :aggregate_field=>@aggregate_locations, :add_placeholder=>"address", :add_input_type=>"TEXT"}
   - cache ['cities-list', *smc_cities] do
     %datalist#location-list
-    = "<!--[if IE 8]><select disabled style='display:none'><![endif]-->"
+      /[if IE 8]
+        <select disabled='disabled' style='display:none;'>
       - smc_cities.each do |city|
         %option{:value=>city}
           = city
-    = "<!--[if IE 8]></select><![endif]-->"
+      /[if IE 8]
+        </select>
 
   = render :partial => "component/search/filter", :locals => {:field=>"service_area", :legend=>"Service Area",:field_value=>params[:service_area], :aggregate_field=>@aggregate_service_areas}
 


### PR DESCRIPTION
Datalist options show up as direct HTML in IE8/9 because the <datalist> element is unsupported. This PR makes turns the <datalist> into a hidden <select> element in IE.
