### PR TITLE
Run tests without an api key in environmental variables.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'coveralls'
 Coveralls.wear!('rails')
 
 ENV["RAILS_ENV"] ||= 'test'
+ENV["OHANA_API_TOKEN"] = "abcd1234" if ENV["OHANA_API_TOKEN"].nil?
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'email_spec'


### PR DESCRIPTION
The README doesn't mention this but the tests fail if there is no api key set in the environmental variables. I just added a simple check to see if there is an api key set and if there isn't, just fake it for the tests.
