### PR TITLE
Add heroku deployment script & remove sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,6 @@ gem "rack-rewrite"
 ## http://railscasts.com/episodes/324-passing-data-to-javascript
 #gem "gon"
 
-# Analytics
-gem "sentry-raven", :git => "https://github.com/getsentry/raven-ruby.git"
 
 # For Google translation API
 gem "google-api-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/getsentry/raven-ruby.git
-  revision: f597e0aef308d51517d519173ced65a87180d849
-  specs:
-    sentry-raven (0.6.0)
-      faraday (>= 0.7.6)
-      hashie (>= 1.1.0)
-      uuidtools
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -135,7 +126,6 @@ GEM
       activesupport (>= 3.1, < 4.1)
       haml (>= 3.1, < 4.1)
       railties (>= 3.1, < 4.1)
-    hashie (2.0.5)
     hike (1.2.3)
     hirb (0.7.1)
     html5shiv-rails (0.0.2)
@@ -356,7 +346,6 @@ DEPENDENCIES
   rspec-rails (>= 2.12.2)
   sass-rails (~> 3.2.3)
   selectivizr-rails
-  sentry-raven!
   uglifier (>= 1.0.3)
   unicorn (>= 4.3.1)
   vcr

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,0 @@
-require 'raven'
-
-Raven.configure do |config|
-  config.dsn = 'https://b74e43fd5ce7444394d1f56c37f3d043:a74c45df1e05482088542cd516bdbaff@app.getsentry.com/13303'
-end

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+while getopts ":a:o:" opt; do
+  case $opt in
+    a)
+      APP_NAME=$OPTARG
+      ;;
+    o)
+      OHANA_API_ENDPOINT=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      echo "Usage: setup_heroku -a your_app_name -o your_api_endpoint" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument" >&2
+      echo "Usage: setup_heroku -a your_app_name -o your_api_endpoint" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Guard clause for APP_NAME option
+if [ -z "$APP_NAME" ]; then
+    echo "Please provide a Heroku application name using the -a option." >&2
+    exit 201
+fi
+
+# Guard clause for OHANA_API_ENDPOINT option
+if [ -z "$OHANA_API_ENDPOINT" ]; then
+    echo "Please provide an Ohana API endpoint using the -o option." >&2
+    exit 202
+fi
+
+# Heroku setup
+echo "Getting ready to set environment variables for $APP_NAME"
+
+echo "Setting CANONICAL_URL"
+heroku config:set CANONICAL_URL=$APP_NAME.herokuapp.com --app $APP_NAME
+
+echo "Setting DOMAIN_NAME"
+heroku config:set DOMAIN_NAME=herokuapp.com --app $APP_NAME
+
+echo "Setting OHANA_API_ENDPOINT"
+heroku config:set OHANA_API_ENDPOINT=$OHANA_API_ENDPOINT --app $APP_NAME
+
+echo "Setting SECRET_TOKEN"
+token2=$(cat /dev/random | LC_CTYPE=C tr -dc "[:alnum:]" | head -c 128)
+heroku config:set SECRET_TOKEN=$token2 --app $APP_NAME
+
+echo "Getting ready to install add-ons for $APP_NAME"
+
+echo "Installing Mandrill by MailChimp"
+heroku addons:add mandrill --app $APP_NAME
+
+echo "Installing Memcachier"
+heroku addons:add memcachier --app $APP_NAME
+
+echo "Installing New Relic"
+heroku addons:add newrelic --app $APP_NAME
+


### PR DESCRIPTION
Sentry should be removed from the project because it's not an essential gem. It's just a tool for getting notified about errors and helps you troubleshoot them. It's up to the redeployment team what debugging and reporting tools they want to use.

@anselmbradford, please review.
