### PR TITLE
Fixes #323 - Removes phone hours

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -3150,11 +3150,6 @@ body { top: 0px !important; }
       font-size:12px;
       color:$greyscale_midtone;
     }
-
-    .phone-hours
-    {
-      font-size:14px;
-    }
   }
 
   .service-opt-box

--- a/app/views/component/organizations/detail/_body.html.haml
+++ b/app/views/component/organizations/detail/_body.html.haml
@@ -64,11 +64,6 @@
                             %p
                               %span{:itemprop=>"contactType"}
                                 = phone["department"]
-                          - if phone["hours"]
-                            %p.phone-hours
-                              %span
-                                = phone["hours"]
-
 
                 - if @org.key?(:faxes)
                   %section.faxes

--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -47,9 +47,8 @@ feature "location details" do
       expect(page).to have_content("Contact")
     end
 
-    it "includes the department, type, and phone hours" do
-      expect(page).to have_content("(650) 372-6200 TTY Information (Monday-Friday,
-        8-5)")
+    it "includes the department and phone type" do
+      expect(page).to have_content("(650) 372-6200 TTY Information")
     end
 
     it "includes the Fax number" do


### PR DESCRIPTION
Removes phone hours from haml, css, and spec because hours can’t be
updated in the accompanying admin interface.
