### PR TITLE
Use ohana-api-test for specs

### DIFF
--- a/config/initializers/ohanapi.rb
+++ b/config/initializers/ohanapi.rb
@@ -7,7 +7,7 @@ Ohanakapa.configure do |config|
   config.api_token = ENV["OHANA_API_TOKEN"]
 
   if Rails.env.test?
-    config.api_endpoint = "http://ohana-api-demo.herokuapp.com/api"
+    config.api_endpoint = "http://ohana-api-test.herokuapp.com/api"
   elsif ENV["OHANA_API_ENDPOINT"].blank?
     raise "The OHANA_API_ENDPOINT environment variable is not set! "+
       "To set it locally, add it to config/application.yml."

--- a/spec/cassettes/Site_Pages/when_visiting_results_page_directly.yml
+++ b/spec/cassettes/Site_Pages/when_visiting_results_page_directly.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -87,12 +87,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -107,6 +107,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:59:45 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/StatusController/GET_/_well-known/status/when_everything_is_fine/returns_success.yml
+++ b/spec/cassettes/StatusController/GET_/_well-known/status/when_everything_is_fine/returns_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-mateo-free-medical-clinic?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -52,17 +52,17 @@ http_interactions:
         Mateo Free Medical Clinic","phones":[{"id":21,"number":"650 578-0400"}],"short_desc":"Provides
         free medical and dental care to those in need. Offers basic medical care for
         adults.","slug":"san-mateo-free-medical-clinic","transportation":"SAMTRANS
-        stops within 1 block.","updated_at":"2014-04-16T19:51:31.212-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/20","services":[{"id":21,"eligibility":"Low-income
+        stops within 1 block.","updated_at":"2014-04-16T19:51:31.212-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":21,"eligibility":"Low-income
         person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
         SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
         screening appointment (650-347-3648).","service_areas":["Belmont","Burlingame","Foster
         City","Millbrae","San Carlos","San Mateo"],"wait":"Varies.","updated_at":"2014-04-16T19:51:31.202-07:00"}],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"}}'
-    http_version: 
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 05:05:06 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -147,12 +147,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -167,6 +167,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 05:05:06 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_a_Google_Maps_directions_link.yml
+++ b/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_a_Google_Maps_directions_link.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -43,13 +43,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":21,"description":"no phone","kind":"Test","mail_address":{"id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
-        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"}}'
-    http_version: 
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
+        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 03:33:57 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -90,8 +90,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":21,"description":"no phone","kind":"Test","mail_address":{"id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
-        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"}}'
-    http_version: 
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
+        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 03:33:57 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_the_physical_address_header.yml
+++ b/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_the_physical_address_header.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -43,13 +43,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":21,"description":"no phone","kind":"Test","mail_address":{"id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
-        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"}}'
-    http_version: 
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
+        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 03:33:56 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -90,8 +90,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":21,"description":"no phone","kind":"Test","mail_address":{"id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
-        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"}}'
-    http_version: 
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-16T19:51:31.443-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/21","services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"organization":{"id":7,"name":"Location
+        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 03:33:56 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/all_results.yml
+++ b/spec/cassettes/all_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations
     body:
       encoding: US-ASCII
       string: ''
@@ -50,13 +50,13 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null},{"id":"21","organization":{"id":7,"name":"Location
-        with no phone","slug":"location-with-no-phone","created_at":"2014-04-16T19:51:31.330-07:00","updated_at":"2014-04-16T19:51:31.516-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"},"services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"updated_at":"2014-04-16T19:51:31.443-07:00","mail_address":{"id":21,"location_id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
+        with no phone","slug":"location-with-no-phone","created_at":"2014-04-16T19:51:31.330-07:00","updated_at":"2014-04-16T19:51:31.516-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"},"services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"updated_at":"2014-04-16T19:51:31.443-07:00","mail_address":{"id":21,"location_id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
         phone","name":"Location with no phone","created_at":"2014-04-16T19:51:31.376-07:00","slug":"location-with-no-phone","short_desc":"no
-        phone","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091376],"highlight":null,"_explanation":null},{"services":[{"id":21,"eligibility":"Low-income
+        phone","url":"http://ohana-api-test.herokuapp.com/api/locations/21","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091376],"highlight":null,"_explanation":null},{"services":[{"id":21,"eligibility":"Low-income
         person without access to health care","fees":"None.","how_to_apply":"Call
         for screening appointment (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
         City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
@@ -64,9 +64,9 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
@@ -78,9 +78,9 @@ http_interactions:
         City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
         9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-demo.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
+        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
         839-1447"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
         839-1457"}],"address":{"id":19,"location_id":19,"street":"114 Fifth Avenue","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides free medical care
         to those in need. Offers basic medical exams for adults and tuberculosis screening.
@@ -100,9 +100,9 @@ http_interactions:
         9-4:30","urls":["http://www.tsagoldenstate.org"],"transportation":"SAMTRANS
         stops within 1 block, BART stops within 3 blocks.","short_desc":"Provides
         emergency food and clothing and furniture vouchers to low-income families
-        in times of crisis.","url":"http://ohana-api-demo.herokuapp.com/api/locations/18","phones":[{"id":19,"location_id":18,"number":"650
+        in times of crisis.","url":"http://ohana-api-test.herokuapp.com/api/locations/18","phones":[{"id":19,"location_id":18,"number":"650
         266-4591"}],"contacts":[{"id":26,"location_id":18,"name":"Kenneth Gibson","title":"Major"}],"id":"18","organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:30.291-07:00","faxes":[{"id":17,"location_id":18,"number":"650
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:30.291-07:00","faxes":[{"id":17,"location_id":18,"number":"650
         266-2594"},{"id":18,"location_id":18,"number":"650 266-4594"}],"address":{"id":18,"location_id":18,"street":"409
         South Spruce Avenue","city":"South San Francisco","state":"CA","zip":"94080"},"description":"Provides
         emergency food, clothing and furniture vouchers to low-income families in
@@ -124,10 +124,10 @@ http_interactions:
         Army","street":"P.O. Box 61868","city":"Sunnyvale","state":"CA","zip":"94088"},"hours":"Monday-Friday,
         9-4","emails":["william_nichols@usw.salvationarmy.org"],"transportation":"VTA
         stops within 4 blocks.","short_desc":"Provides emergency assistance to persons
-        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-demo.herokuapp.com/api/locations/17","phones":[{"id":18,"location_id":17,"number":"408
+        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-test.herokuapp.com/api/locations/17","phones":[{"id":18,"location_id":17,"number":"408
         720-0420"}],"contacts":[{"id":25,"location_id":17,"name":"James Lee","title":"Commanding
         Officer"}],"id":"17","languages":["Korean"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.861-07:00","faxes":[{"id":16,"location_id":17,"number":"408
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.861-07:00","faxes":[{"id":16,"location_id":17,"number":"408
         720-8075"}],"address":{"id":17,"location_id":17,"street":"1161 South Bernardo","city":"Sunnyvale","state":"CA","zip":"94087"},"description":"Provides
         emergency assistance including food and clothing for persons in immediate
         need. Provides PG\u0026E assistance through REACH program. Youth programs
@@ -144,9 +144,9 @@ http_interactions:
         SERVICES","Residential Care","DRUG ABUSE SERVICES"],"updated_at":"2014-04-16T19:51:29.478-07:00"}],"mail_address":{"id":16,"location_id":16,"attention":"Adult
         Rehabilitation Center","street":"1500 Valencia Street","city":"San Francisco","state":"CA","zip":"94110"},"hours":"Monday-Friday,
         8-4","transportation":"MUNI - 26 Valencia, Mission Street lines.","short_desc":"Long-term
-        (6-12 month) residential treatment program for men/women age 21-60.","url":"http://ohana-api-demo.herokuapp.com/api/locations/16","phones":[{"id":17,"location_id":16,"number":"415
+        (6-12 month) residential treatment program for men/women age 21-60.","url":"http://ohana-api-test.herokuapp.com/api/locations/16","phones":[{"id":17,"location_id":16,"number":"415
         643-8000"}],"contacts":[{"id":24,"location_id":16,"name":"Jack Phillips","title":"Administrator"}],"id":"16","languages":["Spanish"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.487-07:00","faxes":[{"id":15,"location_id":16,"number":"415
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.487-07:00","faxes":[{"id":15,"location_id":16,"number":"415
         285-1391"}],"address":{"id":16,"location_id":16,"street":"1500 Valencia Street","city":"San
         Francisco","state":"CA","zip":"94110"},"description":"Provides a long-term
         (6-12 month) residential rehabilitation program for men and women with substance
@@ -171,10 +171,10 @@ http_interactions:
         Deposit Assistance","Utility Service Payment Assistance"],"updated_at":"2014-04-16T19:51:29.058-07:00"}],"mail_address":{"id":15,"location_id":15,"attention":"Salvation
         Army","street":"P.O. Box 1147","city":"Redwood City","state":"CA","zip":"94064"},"urls":["http://www.tsagoldenstate.org"],"transportation":"SAMTRANS
         stops nearby.","short_desc":"Provides a variety of emergency services to low-income
-        persons. Also sponsors recreational and educational activities.","url":"http://ohana-api-demo.herokuapp.com/api/locations/15","phones":[{"id":16,"location_id":15,"number":"650
+        persons. Also sponsors recreational and educational activities.","url":"http://ohana-api-test.herokuapp.com/api/locations/15","phones":[{"id":16,"location_id":15,"number":"650
         368-4643"}],"contacts":[{"id":23,"location_id":15,"name":"Andres Espinoza","title":"Captain,
         Commanding Officer"}],"id":"15","languages":["Spanish"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.067-07:00","faxes":[{"id":14,"location_id":15,"number":"650
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.067-07:00","faxes":[{"id":14,"location_id":15,"number":"650
         364-1712"}],"address":{"id":15,"location_id":15,"street":"660 Veterans Blvd.","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides food, clothing,
         bus tokens and shelter to individuals and families in times of crisis from
@@ -190,9 +190,9 @@ http_interactions:
         wait.","funding_sources":["City"],"service_areas":["San Mateo County"],"keywords":["EDUCATION
         SERVICES","Library","Libraries","Public Libraries"],"updated_at":"2014-04-16T19:51:28.610-07:00"}],"mail_address":{"id":14,"location_id":14,"attention":"Redwood
         Shores Branch","street":"399 Marine Parkway","city":"Redwood City","state":"CA","zip":"94065"},"urls":["http://www.redwoodcity.org/library"],"short_desc":"Provides
-        general reading materials and reference services.","url":"http://ohana-api-demo.herokuapp.com/api/locations/14","phones":[{"id":15,"location_id":14,"number":"650
+        general reading materials and reference services.","url":"http://ohana-api-test.herokuapp.com/api/locations/14","phones":[{"id":15,"location_id":14,"number":"650
         780-5740"}],"contacts":[{"id":22,"location_id":14,"name":"Dave Genesy","title":"Library
-        Director"}],"id":"14","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.623-07:00","address":{"id":14,"location_id":14,"street":"399
+        Director"}],"id":"14","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.623-07:00","address":{"id":14,"location_id":14,"street":"399
         Marine Parkway.","city":"Redwood City","state":"CA","zip":"94065"},"description":"Provides
         general reading materials, including large-type books, videos, music cassettes
         and CDs, and books on tape. Offers children''s programs and a Summer Reading
@@ -208,9 +208,9 @@ http_interactions:
         Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-8:30; Friday, 10-5","urls":["http://www.projectreadredwoodcity.org"],"emails":["rclread@redwoodcity.org"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Offers an intergenerational literacy
-        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-demo.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
+        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-test.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
         780-7077"}],"contacts":[{"id":21,"location_id":13,"name":"Kathy Endaya","title":"Director"}],"id":"13","organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
         780-7004"}],"address":{"id":13,"location_id":13,"street":"1044 Middlefield
         Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"description":"Offers
         an intergenerational literacy program for youth and English-speaking adults
@@ -230,10 +230,10 @@ http_interactions:
         SERVICES","Library","Libraries","Public Libraries"],"updated_at":"2014-04-16T19:51:27.847-07:00"}],"mail_address":{"id":12,"location_id":12,"attention":"Schaberg
         Branch","street":"2140 Euclid Avenue","city":"Redwood City","state":"CA","zip":"94061"},"hours":"Tuesday-Thursday,
         1-6, Saturday, 10-3","transportation":"SAMTRANS stops within 1 block.","short_desc":"Provides
-        general reading materials and reference services.","url":"http://ohana-api-demo.herokuapp.com/api/locations/12","phones":[{"id":13,"location_id":12,"number":"650
+        general reading materials and reference services.","url":"http://ohana-api-test.herokuapp.com/api/locations/12","phones":[{"id":13,"location_id":12,"number":"650
         780-7010"}],"contacts":[{"id":19,"location_id":12,"name":"Dave Genesy","title":"Library
         Director"},{"id":20,"location_id":12,"name":"Elizabeth Meeks","title":"Branch
-        Manager"}],"id":"12","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.856-07:00","faxes":[{"id":12,"location_id":12,"number":"650
+        Manager"}],"id":"12","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.856-07:00","faxes":[{"id":12,"location_id":12,"number":"650
         365-3738"}],"address":{"id":12,"location_id":12,"street":"2140 Euclid Avenue.","city":"Redwood
         City","state":"CA","zip":"94061"},"description":"Provides general reading
         materials, including large-type books, DVD''s and CDs, books on CD and some
@@ -247,11 +247,11 @@ http_interactions:
         Library","street":"1044 Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-9; Friday, Saturday, 10-5; Sunday, 12-5","urls":["http://www.redwoodcity.org/library"],"emails":["rclinfo@redwoodcity.org"],"transportation":"SAMTRANS
         stops within 1 block; CALTRAIN stops within 1 block.","short_desc":"Provides
-        general reference and reading materials to adults, teenagers and children.","url":"http://ohana-api-demo.herokuapp.com/api/locations/11","phones":[{"id":12,"location_id":11,"number":"650
+        general reference and reading materials to adults, teenagers and children.","url":"http://ohana-api-test.herokuapp.com/api/locations/11","phones":[{"id":12,"location_id":11,"number":"650
         780-7018","department":"Circulation"}],"contacts":[{"id":17,"location_id":11,"name":"Dave
         Genesy","title":"Library Director"},{"id":18,"location_id":11,"name":"Maria
         Kramer","title":"Library Division Manager"}],"id":"11","languages":["Spanish"],"organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.441-07:00","faxes":[{"id":11,"location_id":11,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.441-07:00","faxes":[{"id":11,"location_id":11,"number":"650
         780-7069"}],"address":{"id":11,"location_id":11,"street":"1044 Middlefield
         Road","city":"Redwood City","state":"CA","zip":"94063"},"description":"Provides
         general reading and media materials, literacy and homework assistance, and
@@ -271,11 +271,11 @@ http_interactions:
         Libraries"],"updated_at":"2014-04-16T19:51:26.997-07:00"}],"mail_address":{"id":10,"location_id":10,"attention":"Fair
         Oaks Branch","street":"2510 Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-7; Friday, 10-5","transportation":"SAMTRANS stops in front.","short_desc":"Provides
-        general reading materials and reference services.","url":"http://ohana-api-demo.herokuapp.com/api/locations/10","phones":[{"id":11,"location_id":10,"number":"650
+        general reading materials and reference services.","url":"http://ohana-api-test.herokuapp.com/api/locations/10","phones":[{"id":11,"location_id":10,"number":"650
         780-7261"}],"contacts":[{"id":15,"location_id":10,"name":"Dave Genesy","title":"Library
         Director"},{"id":16,"location_id":10,"name":"Maria Kramer","title":"Library
         Divisions Manager"}],"id":"10","languages":["Spanish"],"organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.006-07:00","faxes":[{"id":10,"location_id":10,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.006-07:00","faxes":[{"id":10,"location_id":10,"number":"650
         569-3371"}],"address":{"id":10,"location_id":10,"street":"2510 Middlefield
         Road","city":"Redwood City","state":"CA","zip":"94063"},"description":"Provides
         general reading material, including bilingual, multi-cultural books, CDs and
@@ -294,11 +294,11 @@ http_interactions:
         times: Monday-Friday, 9-1:30","urls":["http://www.peninsulavolunteers.org"],"emails":["mbaker-venturini@peninsulavolunteers.org"],"transportation":"Not
         necessary for service.","short_desc":"Will deliver a hot meal to the home
         of persons age 60 or over who are homebound and unable to prepare their own
-        meals. Can provide special diets.","url":"http://ohana-api-demo.herokuapp.com/api/locations/9","phones":[{"id":10,"location_id":9,"number":"650
+        meals. Can provide special diets.","url":"http://ohana-api-test.herokuapp.com/api/locations/9","phones":[{"id":10,"location_id":9,"number":"650
         323-2022"}],"contacts":[{"id":12,"location_id":9,"name":"Marilyn Baker-Venturini","title":"Director"},{"id":13,"location_id":9,"name":"Graciela
         Hernandez","title":"Assistant Manager"},{"id":14,"location_id":9,"name":"Julie
         Avelino","title":"Assessment Specialist"}],"id":"9","languages":["Spanish"],"organization":{"id":3,"name":"Peninsula
-        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.487-07:00","faxes":[{"id":9,"location_id":9,"number":"650
+        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.487-07:00","faxes":[{"id":9,"location_id":9,"number":"650
         326-9547"}],"address":{"id":9,"location_id":9,"street":"800 Middle Avenue","city":"Menlo
         Park","state":"CA","zip":"94025-9881"},"description":"Delivers a hot meal
         to the home of persons age 60 or over who are primarily homebound and unable
@@ -321,11 +321,11 @@ http_interactions:
         House","street":"500 Arbor Road","city":"Menlo Park","state":"CA","zip":"94025"},"hours":"Monday-Friday,
         8-5:30","urls":["http://www.penvol.org/rosenerhouse"],"emails":["bkalt@peninsulavolunteers.org","fmarchick@peninsulavolunteers.org"],"transportation":"Transportation
         can be arranged via Redi-Wheels or Outreach.","short_desc":"A day center for
-        adults age 50 or over.","url":"http://ohana-api-demo.herokuapp.com/api/locations/8","phones":[{"id":9,"location_id":8,"number":"650
+        adults age 50 or over.","url":"http://ohana-api-test.herokuapp.com/api/locations/8","phones":[{"id":9,"location_id":8,"number":"650
         322-0126"}],"contacts":[{"id":10,"location_id":8,"name":"Bart Charlow","title":"Executive
         Director, Peninsula Volunteers"},{"id":11,"location_id":8,"name":"Barbara
         Kalt","title":"Director"}],"id":"8","languages":["Spanish","Filipino (Tagalog)","Vietnamese"],"organization":{"id":3,"name":"Peninsula
-        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.018-07:00","faxes":[{"id":8,"location_id":8,"number":"650
+        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.018-07:00","faxes":[{"id":8,"location_id":8,"number":"650
         322-4067"}],"address":{"id":8,"location_id":8,"street":"500 Arbor Road","city":"Menlo
         Park","state":"CA","zip":"94025"},"description":"Rosener House is a day center
         for older adults who may be unable to live independently but do not require
@@ -359,11 +359,11 @@ http_interactions:
         House","street":"800 Middle Avenue","city":"Menlo Park","state":"CA","zip":"94025-9881"},"hours":"Monday-Thursday,
         8 am-9 pm; Friday, 8-5","urls":["http://www.penvol.org/littlehouse"],"emails":["polson@peninsulavolunteers.org"],"transportation":"SAMTRANS
         stops within 3 blocks, RediWheels and Menlo Park Shuttle stop at door.","short_desc":"A
-        multipurpose senior citizens'' center.","url":"http://ohana-api-demo.herokuapp.com/api/locations/7","phones":[{"id":8,"location_id":7,"number":"650
+        multipurpose senior citizens'' center.","url":"http://ohana-api-test.herokuapp.com/api/locations/7","phones":[{"id":8,"location_id":7,"number":"650
         326-2025"}],"contacts":[{"id":8,"location_id":7,"name":"Peter Olson","title":"Little
         House Director"},{"id":9,"location_id":7,"name":"Bart Charlow","title":"Executive
         Director, Peninsula Volunteers"}],"id":"7","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":3,"name":"Peninsula
-        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:25.586-07:00","faxes":[{"id":7,"location_id":7,"number":"650
+        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:25.586-07:00","faxes":[{"id":7,"location_id":7,"number":"650
         326-9547"}],"address":{"id":7,"location_id":7,"street":"800 Middle Avenue","city":"Menlo
         Park","state":"CA","zip":"94025-9881"},"description":"A multipurpose center
         offering a wide variety of recreational, education and cultural activities.
@@ -394,10 +394,10 @@ http_interactions:
         Mateo County"],"keywords":["COMMUNITY SERVICES","Speakers","Automobile Loans"],"updated_at":"2014-04-16T19:51:25.102-07:00"}],"mail_address":{"id":6,"location_id":6,"attention":"Economic
         Self - Sufficiency Program","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"urls":["http://www.peninsulafamilyservice.org"],"emails":["waystowork@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block. CALTRAIN stops within 6 blocks.","short_desc":"Makes
-        small loans to working families.","url":"http://ohana-api-demo.herokuapp.com/api/locations/6","phones":[{"id":7,"location_id":6,"number":"650
+        small loans to working families.","url":"http://ohana-api-test.herokuapp.com/api/locations/6","phones":[{"id":7,"location_id":6,"number":"650
         403-4300","extension":"4100"}],"contacts":[{"id":7,"location_id":6,"name":"Joe
         Bloom","title":"Financial Empowerment Programs Program Director"}],"id":"6","languages":["Hindi","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:25.113-07:00","faxes":[{"id":6,"location_id":6,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:25.113-07:00","faxes":[{"id":6,"location_id":6,"number":"650
         403-4303"}],"address":{"id":6,"location_id":6,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides fixed 8% short
         term loans to eligible applicants for the purchase of a reliable, used autmobile.
@@ -418,10 +418,10 @@ http_interactions:
         10-6; Tuesday-Friday, 10-8; Saturday, Sunday, 9:30-5:30","urls":["http://www.peninsulafamilyservice.org"],"emails":["kpesavento@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 4 blocks.","short_desc":"Provides
         supervised visitation services and a neutral site for parents in extremely
-        hostile divorces to carry out supervised exchanges of children.","url":"http://ohana-api-demo.herokuapp.com/api/locations/5","phones":[{"id":6,"location_id":5,"number":"650
+        hostile divorces to carry out supervised exchanges of children.","url":"http://ohana-api-test.herokuapp.com/api/locations/5","phones":[{"id":6,"location_id":5,"number":"650
         403-4300","extension":"4500"}],"contacts":[{"id":6,"location_id":5,"name":"Kimberly
         Pesavento","title":"Director of Visitation"}],"id":"5","languages":["Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.690-07:00","faxes":[{"id":5,"location_id":5,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.690-07:00","faxes":[{"id":5,"location_id":5,"number":"650
         403-4303"}],"address":{"id":5,"location_id":5,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides supervised visitation
         services and a neutral site for parents to carry out supervised exchanges
@@ -444,11 +444,11 @@ http_interactions:
         Senior Peer Counseling","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Any
         time that is convenient for the client and peer counselor","transportation":"Service
         is provided in person''s home or at a mutually agreed upon location.","short_desc":"Offers
-        supportive counseling services to older persons.","url":"http://ohana-api-demo.herokuapp.com/api/locations/4","phones":[{"id":5,"location_id":4,"number":"650
+        supportive counseling services to older persons.","url":"http://ohana-api-test.herokuapp.com/api/locations/4","phones":[{"id":5,"location_id":4,"number":"650
         403-4300","department":"English"}],"contacts":[{"id":5,"location_id":4,"name":"Howard
         Lader, LCSW","title":"Manager, Senior Peer Counseling"}],"id":"4","languages":["Chinese
         (Cantonese)","Chinese (Mandarin)","Filipino (Tagalog)","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.268-07:00","faxes":[{"id":4,"location_id":4,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.268-07:00","faxes":[{"id":4,"location_id":4,"number":"650
         403-4303"}],"address":{"id":4,"location_id":4,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Offers supportive counseling
         services to San Mateo County residents age 55 or over. Volunteer counselors
@@ -473,11 +473,11 @@ http_interactions:
         9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["bbrown@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 6 blocks.","short_desc":"Provides
         training and job placement to eligible persons age 55 or over. All persons
-        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-demo.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
+        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-test.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
         403-4300","extension":"Ext. 4385"}],"contacts":[{"id":4,"location_id":3,"name":"Brenda
         Brown","title":"Director, Second Career Services"}],"id":"3","languages":["Chinese
         (Mandarin)","Filipino (Tagalog)","Italian","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
         403-4302"}],"address":{"id":3,"location_id":3,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides training and job
         placement to eligible people age 55 or over who meet certain income qualifications.
@@ -504,11 +504,11 @@ http_interactions:
         Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
         City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-demo.herokuapp.com/api/locations/2","phones":[{"id":3,"location_id":2,"number":"650
+        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/2","phones":[{"id":3,"location_id":2,"number":"650
         780-7525"}],"contacts":[{"id":2,"location_id":2,"name":"Susan Houston","title":"Director
         of Older Adult Services"},{"id":3,"location_id":2,"name":"Christina Gonzalez","title":"Center
         Director"}],"id":"2","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.454-07:00","faxes":[{"id":2,"location_id":2,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.454-07:00","faxes":[{"id":2,"location_id":2,"number":"650
         701-0856"}],"address":{"id":2,"location_id":2,"street":"2600 Middlefield Road","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"A walk-in center for older
         adults that provides social services, wellness, recreational, educational
@@ -571,12 +571,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -591,6 +591,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397702909958],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 05:00:52 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/dynamic/location_details/phone_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/phone_dynamic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -60,7 +60,7 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"<%= number %>"},{"id":2,"department":"Reservations","number":"<%= number %>"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -97,12 +97,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
     http_version:
   recorded_at: Thu, 17 Apr 2014 03:38:57 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -160,7 +160,7 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"<%= number %>"},{"id":2,"department":"Reservations","number":"<%= number %>"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -197,7 +197,7 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
     http_version:
   recorded_at: Thu, 17 Apr 2014 03:38:57 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/dynamic/location_details/superscript_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/superscript_dynamic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -60,7 +60,7 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"<%= name %>","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -97,12 +97,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
     http_version:
   recorded_at: Thu, 17 Apr 2014 03:46:23 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -160,7 +160,7 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"<%= name %>","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -197,7 +197,7 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
     http_version:
   recorded_at: Thu, 17 Apr 2014 03:46:23 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/dynamic/location_details/url_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/url_dynamic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -61,7 +61,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -98,12 +98,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
     http_version:
   recorded_at: Thu, 17 Apr 2014 03:49:05 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -162,7 +162,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["<%= url %>","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["<%= url %>","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -199,7 +199,7 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
     http_version:
   recorded_at: Thu, 17 Apr 2014 03:49:05 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/when_clicking_a_category.yml
+++ b/spec/cassettes/homepage_search/when_clicking_a_category.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20Insurance
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20Insurance
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 10:21:23 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+Insurance&page=7>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+Insurance&page=2>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+Insurance&page=7>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+Insurance&page=2>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -68,11 +68,11 @@ http_interactions:
         Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
         City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-demo.herokuapp.com/api/locations/2","phones":[{"id":3,"location_id":2,"number":"650
+        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/2","phones":[{"id":3,"location_id":2,"number":"650
         780-7525"}],"contacts":[{"id":2,"location_id":2,"name":"Susan Houston","title":"Director
         of Older Adult Services"},{"id":3,"location_id":2,"name":"Christina Gonzalez","title":"Center
         Director"}],"id":"2","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.454-07:00","faxes":[{"id":2,"location_id":2,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.454-07:00","faxes":[{"id":2,"location_id":2,"number":"650
         701-0856"}],"address":{"id":2,"location_id":2,"street":"2600 Middlefield Road","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"A walk-in center for older
         adults that provides social services, wellness, recreational, educational
@@ -96,6 +96,6 @@ http_interactions:
         Agency of San Mateo County, Fair Oaks Intergenerational Center.","name":"Fair
         Oaks Adult Activity Center","created_at":"2014-04-16T19:51:23.059-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.0056869555,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:24 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/when_searching_for_food_stamps_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_food_stamps_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food%20stamps&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food%20stamps&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 10:21:23 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&page=5&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&page=5&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -66,9 +66,9 @@ http_interactions:
         9-4:30","urls":["http://www.tsagoldenstate.org"],"transportation":"SAMTRANS
         stops within 1 block, BART stops within 3 blocks.","short_desc":"Provides
         emergency food and clothing and furniture vouchers to low-income families
-        in times of crisis.","url":"http://ohana-api-demo.herokuapp.com/api/locations/18","phones":[{"id":19,"location_id":18,"number":"650
+        in times of crisis.","url":"http://ohana-api-test.herokuapp.com/api/locations/18","phones":[{"id":19,"location_id":18,"number":"650
         266-4591"}],"contacts":[{"id":26,"location_id":18,"name":"Kenneth Gibson","title":"Major"}],"id":"18","organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:30.291-07:00","faxes":[{"id":17,"location_id":18,"number":"650
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:30.291-07:00","faxes":[{"id":17,"location_id":18,"number":"650
         266-2594"},{"id":18,"location_id":18,"number":"650 266-4594"}],"address":{"id":18,"location_id":18,"street":"409
         South Spruce Avenue","city":"South San Francisco","state":"CA","zip":"94080"},"description":"Provides
         emergency food, clothing and furniture vouchers to low-income families in
@@ -78,6 +78,6 @@ http_interactions:
         as Sunday services and spiritual counseling. Provides Christmas toys and Back-to-School
         clothes and supplies. Offers case management, advocacy and referrals to other
         agencies.","name":"South San Francisco Citadel Corps","created_at":"2014-04-16T19:51:29.983-07:00","longitude":-122.4224905,"slug":"south-san-francisco-citadel-corps","latitude":37.6445898,"coordinates":[-122.4224905,37.6445898],"accessibility":["Wheelchair"],"_score":0.0032592355,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:24 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/when_searching_for_health_care_reform_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_health_care_reform_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20care%20reform&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20care%20reform&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 10:21:23 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&page=10&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&page=10&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -62,9 +62,9 @@ http_interactions:
         City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
         9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-demo.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
+        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
         839-1447"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
         839-1457"}],"address":{"id":19,"location_id":19,"street":"114 Fifth Avenue","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides free medical care
         to those in need. Offers basic medical exams for adults and tuberculosis screening.
@@ -73,6 +73,6 @@ http_interactions:
         hygiene instruction for children, age 3-12, of Samaritan House clients.","name":"Redwood
         City Free Medical Clinic","created_at":"2014-04-16T19:51:30.465-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
         Restroom","Wheelchair"],"_score":0.0048367744,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:24 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/when_searching_for_sfmnp_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_sfmnp_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:25 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/when_searching_for_wic_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_wic_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:24 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:26 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -87,12 +87,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -107,6 +107,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:26 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -62,7 +62,7 @@ http_interactions:
         372-6200"}],"short_desc":"This is an example of a short description. Maybe
         a little too short. What do you ththink? Should it go on some more? But not
         too much. Ok, I think that''s good.","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-17T06:08:17.787-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-17T06:08:17.787-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -99,12 +99,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
-    http_version: 
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 16:18:37 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -164,7 +164,7 @@ http_interactions:
         372-6200"}],"short_desc":"This is an example of a short description. Maybe
         a little too short. What do you ththink? Should it go on some more? But not
         too much. Ok, I think that''s good.","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-17T06:08:17.787-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-17T06:08:17.787-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -201,7 +201,7 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
-    http_version: 
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 16:18:39 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/foobar?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/foobar?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -44,6 +44,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"Not Found","message":"The requested resource could not be
         found."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 03:31:12 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_via_search_results/includes_address_elements.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_via_search_results/includes_address_elements.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -87,12 +87,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -107,11 +107,11 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:32:59 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -207,12 +207,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
-    http_version: 
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:32:59 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -271,7 +271,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -308,7 +308,7 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
-    http_version: 
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:32:59 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/location_details/when_you_return_to_the_results_page_from_details_page/displays_the_same_search_results.yml
+++ b/spec/cassettes/location_details/when_you_return_to_the_results_page_from_details_page/displays_the_same_search_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -87,12 +87,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -107,11 +107,11 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:42:52 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -207,12 +207,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
-    http_version: 
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:42:53 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
     body:
       encoding: US-ASCII
       string: ''
@@ -271,7 +271,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":1,"department":"Information","number":"650 372-6200"},{"id":2,"department":"Reservations","number":"650
         372-6200"}],"short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
         PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-demo.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
+        stops within 1 block","updated_at":"2014-04-16T19:48:31.128-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":2,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -308,12 +308,12 @@ http_interactions:
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
         wait to 2 weeks","updated_at":"2014-04-16T19:48:30.962-07:00"}],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"}}'
-    http_version: 
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:42:53 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -398,12 +398,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -418,6 +418,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:42:54 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/less_than_3_pages_in_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/less_than_3_pages_in_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:51 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:52 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=3&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=3&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -89,10 +89,10 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:51 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=4&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=4&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -128,13 +128,13 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703090911],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:52 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/less_than_3_pages_out_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/less_than_3_pages_out_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:50 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -89,8 +89,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:50 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -155,12 +155,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -175,11 +175,11 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397702909958],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=20&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=20&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -204,10 +204,10 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:50 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=19&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=19&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -247,11 +247,11 @@ http_interactions:
         9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["bbrown@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 6 blocks.","short_desc":"Provides
         training and job placement to eligible persons age 55 or over. All persons
-        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-demo.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
+        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-test.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
         403-4300","extension":"Ext. 4385"}],"contacts":[{"id":4,"location_id":3,"name":"Brenda
         Brown","title":"Director, Second Career Services"}],"id":"3","languages":["Chinese
         (Mandarin)","Filipino (Tagalog)","Italian","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
         403-4302"}],"address":{"id":3,"location_id":3,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides training and job
         placement to eligible people age 55 or over who meet certain income qualifications.
@@ -265,6 +265,6 @@ http_interactions:
         job bank. Also provides referrals to classroom training. Formerly known as
         Family Service Agency of San Mateo County, Senior Employment Services.","name":"Second
         Career Employment Program","created_at":"2014-04-16T19:51:23.612-07:00","slug":"second-career-employment-program","longitude":-122.3263232,"latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703083612],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/more_than_3_pages_in_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/more_than_3_pages_in_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:50 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:51 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=4&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=4&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -89,10 +89,10 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:50 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=5&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=3&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=5&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -128,9 +128,9 @@ http_interactions:
         City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
         9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-demo.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
+        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
         839-1447"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
         839-1457"}],"address":{"id":19,"location_id":19,"street":"114 Fifth Avenue","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides free medical care
         to those in need. Offers basic medical exams for adults and tuberculosis screening.
@@ -139,6 +139,6 @@ http_interactions:
         hygiene instruction for children, age 3-12, of Samaritan House clients.","name":"Redwood
         City Free Medical Clinic","created_at":"2014-04-16T19:51:30.465-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
         Restroom","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703090465],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:51 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/more_than_3_pages_out_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/more_than_3_pages_out_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:49 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -89,8 +89,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:49 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -155,12 +155,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -175,11 +175,11 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397702909958],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=18&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=18&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -204,10 +204,10 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:49 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=17&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=19&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=17&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=19&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -247,10 +247,10 @@ http_interactions:
         10-6; Tuesday-Friday, 10-8; Saturday, Sunday, 9:30-5:30","urls":["http://www.peninsulafamilyservice.org"],"emails":["kpesavento@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 4 blocks.","short_desc":"Provides
         supervised visitation services and a neutral site for parents in extremely
-        hostile divorces to carry out supervised exchanges of children.","url":"http://ohana-api-demo.herokuapp.com/api/locations/5","phones":[{"id":6,"location_id":5,"number":"650
+        hostile divorces to carry out supervised exchanges of children.","url":"http://ohana-api-test.herokuapp.com/api/locations/5","phones":[{"id":6,"location_id":5,"number":"650
         403-4300","extension":"4500"}],"contacts":[{"id":6,"location_id":5,"name":"Kimberly
         Pesavento","title":"Director of Visitation"}],"id":"5","languages":["Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.690-07:00","faxes":[{"id":5,"location_id":5,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.690-07:00","faxes":[{"id":5,"location_id":5,"number":"650
         403-4303"}],"address":{"id":5,"location_id":5,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides supervised visitation
         services and a neutral site for parents to carry out supervised exchanges
@@ -265,6 +265,6 @@ http_interactions:
         held at various sites throughout the county. Call 650-403-4300 ext. 4500 to
         register. Formerly known as Family Service Agency of San Mateo County, Family
         Visitation Center.","name":"Family Visitation Center","created_at":"2014-04-16T19:51:24.425-07:00","slug":"family-visitation-center","longitude":-122.3263232,"latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703084425],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/on_first_page_with_less_than_4_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_first_page_with_less_than_4_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:48 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -65,9 +65,9 @@ http_interactions:
         Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-8:30; Friday, 10-5","urls":["http://www.projectreadredwoodcity.org"],"emails":["rclread@redwoodcity.org"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Offers an intergenerational literacy
-        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-demo.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
+        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-test.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
         780-7077"}],"contacts":[{"id":21,"location_id":13,"name":"Kathy Endaya","title":"Director"}],"id":"13","organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
         780-7004"}],"address":{"id":13,"location_id":13,"street":"1044 Middlefield
         Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"description":"Offers
         an intergenerational literacy program for youth and English-speaking adults
@@ -81,6 +81,6 @@ http_interactions:
         fundraising board that helps to support and to fund Redwood City''s Project
         Read. Call for more information about each service.","name":"Project Read","created_at":"2014-04-16T19:51:27.978-07:00","longitude":-122.227409,"slug":"project-read","latitude":37.4837662,"coordinates":[-122.227409,37.4837662],"accessibility":["Elevator","Ramp","Disabled
         Restroom","Disabled Parking"],"_score":0.00893393,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:49 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/on_first_page_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_first_page_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:52 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,10 +56,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:52 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/on_last_page_with_less_than_4_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_last_page_with_less_than_4_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:51 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -65,9 +65,9 @@ http_interactions:
         Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-8:30; Friday, 10-5","urls":["http://www.projectreadredwoodcity.org"],"emails":["rclread@redwoodcity.org"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Offers an intergenerational literacy
-        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-demo.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
+        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-test.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
         780-7077"}],"contacts":[{"id":21,"location_id":13,"name":"Kathy Endaya","title":"Director"}],"id":"13","organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
         780-7004"}],"address":{"id":13,"location_id":13,"street":"1044 Middlefield
         Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"description":"Offers
         an intergenerational literacy program for youth and English-speaking adults
@@ -81,11 +81,11 @@ http_interactions:
         fundraising board that helps to support and to fund Redwood City''s Project
         Read. Call for more information about each service.","name":"Project Read","created_at":"2014-04-16T19:51:27.978-07:00","longitude":-122.227409,"slug":"project-read","latitude":37.4837662,"coordinates":[-122.227409,37.4837662],"accessibility":["Elevator","Ramp","Disabled
         Restroom","Disabled Parking"],"_score":0.00893393,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:51 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -110,8 +110,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:51 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -149,16 +149,16 @@ http_interactions:
         Army","street":"P.O. Box 61868","city":"Sunnyvale","state":"CA","zip":"94088"},"hours":"Monday-Friday,
         9-4","emails":["william_nichols@usw.salvationarmy.org"],"transportation":"VTA
         stops within 4 blocks.","short_desc":"Provides emergency assistance to persons
-        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-demo.herokuapp.com/api/locations/17","phones":[{"id":18,"location_id":17,"number":"408
+        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-test.herokuapp.com/api/locations/17","phones":[{"id":18,"location_id":17,"number":"408
         720-0420"}],"contacts":[{"id":25,"location_id":17,"name":"James Lee","title":"Commanding
         Officer"}],"id":"17","languages":["Korean"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.861-07:00","faxes":[{"id":16,"location_id":17,"number":"408
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.861-07:00","faxes":[{"id":16,"location_id":17,"number":"408
         720-8075"}],"address":{"id":17,"location_id":17,"street":"1161 South Bernardo","city":"Sunnyvale","state":"CA","zip":"94087"},"description":"Provides
         emergency assistance including food and clothing for persons in immediate
         need. Provides PG\u0026E assistance through REACH program. Youth programs
         offer tutoring, music and troops. Information on related resources is available.
         Also provides rental assistance when funds are available.","name":"Sunnyvale
         Corps","created_at":"2014-04-16T19:51:29.608-07:00","longitude":-122.0600024,"slug":"sunnyvale-corps","latitude":37.3569004,"coordinates":[-122.0600024,37.3569004],"_score":0.00683466,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:51 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/on_last_page_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_last_page_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:52 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:53 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -89,8 +89,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:45:52 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -155,12 +155,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -175,6 +175,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397702909958],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:53 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/when_there_are_no_results.yml
+++ b/spec/cassettes/results_page_pagination/when_there_are_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:52 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_result.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -87,12 +87,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -107,6 +107,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:45:50 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:33:59 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -80,8 +80,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:33:58 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -109,15 +109,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:33:59 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -166,11 +166,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:51:21 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -195,8 +195,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:38:28 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=22&service-area-option=&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=2&service-area-option=&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=22&service-area-option=&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=2&service-area-option=&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -224,15 +224,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:38:29 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=3
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=3
     body:
       encoding: US-ASCII
       string: ''
@@ -257,10 +257,10 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:38:29 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=1>;
-        rel="first", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2>;
-        rel="prev", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=4>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=1>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=4>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -296,18 +296,18 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703090911],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:38:29 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -332,8 +332,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:40:14 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -367,13 +367,13 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703090911],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:40:15 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_has_results.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:02 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -80,8 +80,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:01 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -115,18 +115,18 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703090911],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:02 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -167,11 +167,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:51:28 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -220,6 +220,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:51:28 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_no_results.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:09 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=United%20States%20Government&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=United%20States%20Government&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,11 +104,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:10 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -149,11 +149,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:18:53 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -202,11 +202,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:18:53 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -255,11 +255,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:08 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -308,6 +308,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:30:48 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_custom_value_is_added.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_custom_value_is_added.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:03 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -96,11 +96,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:30:47 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -149,11 +149,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:30:47 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -202,6 +202,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:52:49 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:12 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:19 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,11 +104,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:01:49 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -149,11 +149,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:28:14 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -202,6 +202,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:28:14 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_clicking_organization_link_in_results.yml
+++ b/spec/cassettes/results_page_search/when_clicking_organization_link_in_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:15 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan%20House&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan%20House&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -80,8 +80,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:15 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=6&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=6&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -115,9 +115,9 @@ http_interactions:
         City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
         9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-demo.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
+        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
         839-1447"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
         839-1457"}],"address":{"id":19,"location_id":19,"street":"114 Fifth Avenue","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides free medical care
         to those in need. Offers basic medical exams for adults and tuberculosis screening.
@@ -126,11 +126,11 @@ http_interactions:
         hygiene instruction for children, age 3-12, of Samaritan House clients.","name":"Redwood
         City Free Medical Clinic","created_at":"2014-04-16T19:51:30.465-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
         Restroom","Wheelchair"],"_score":0.03791304,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:16 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House
     body:
       encoding: US-ASCII
       string: ''
@@ -155,8 +155,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:15 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -190,18 +190,18 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703090911],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:16 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -250,11 +250,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:41:17 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -303,6 +303,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:18:45 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_clicking_the_reset_button.yml
+++ b/spec/cassettes/results_page_search/when_clicking_the_reset_button.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -43,11 +43,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:13 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -96,11 +96,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:13 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -149,11 +149,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:14 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -178,8 +178,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:13 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -207,15 +207,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:14 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -256,11 +256,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:16 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -309,11 +309,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:23:01 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -362,6 +362,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:40:09 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:33:54 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -80,8 +80,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:33:54 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=22&service-area-option=&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=2&service-area-option=&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=22&service-area-option=&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=2&service-area-option=&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -109,15 +109,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:33:55 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=fairfax,%20va&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=fairfax,%20va&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -166,11 +166,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:33:55 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -195,8 +195,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:51:33 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -224,10 +224,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:51:34 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_has_results.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:03 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,11 +104,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:04 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San%20Mateo,%20CA&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San%20Mateo,%20CA&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -133,8 +133,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:04 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=6&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=6&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -172,11 +172,11 @@ http_interactions:
         9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["bbrown@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 6 blocks.","short_desc":"Provides
         training and job placement to eligible persons age 55 or over. All persons
-        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-demo.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
+        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-test.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
         403-4300","extension":"Ext. 4385"}],"contacts":[{"id":4,"location_id":3,"name":"Brenda
         Brown","title":"Director, Second Career Services"}],"id":"3","languages":["Chinese
         (Mandarin)","Filipino (Tagalog)","Italian","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
         403-4302"}],"address":{"id":3,"location_id":3,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides training and job
         placement to eligible people age 55 or over who meet certain income qualifications.
@@ -190,6 +190,6 @@ http_interactions:
         job bank. Also provides referrals to classroom training. Formerly known as
         Family Service Agency of San Mateo County, Senior Employment Services.","name":"Second
         Career Employment Program","created_at":"2014-04-16T19:51:23.612-07:00","slug":"second-career-employment-program","longitude":-122.3263232,"latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.07871992834851854],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:04 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_no_results.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:08 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=San%20Mateo,%20CA&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=San%20Mateo,%20CA&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,11 +104,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:09 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -157,11 +157,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:28:19 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -210,11 +210,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:46:07 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -255,11 +255,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:22:53 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -308,6 +308,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:22:53 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_custom_value_is_added.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_custom_value_is_added.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:13 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,11 +104,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:15 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -149,11 +149,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:52:46 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -202,6 +202,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:52:46 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:41:22 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -96,11 +96,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:55:14 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -149,6 +149,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:55:14 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:05 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,6 +104,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:55:10 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:11 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -80,8 +80,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:10 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -109,15 +109,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:11 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -142,8 +142,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 08:34:11 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -171,15 +171,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:11 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -220,11 +220,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:01:56 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -273,11 +273,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:01:56 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -318,11 +318,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 10:21:01 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -347,8 +347,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 21:46:52 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=22&service-area-option=&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=2&service-area-option=&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=22&service-area-option=&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=2&service-area-option=&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -376,10 +376,10 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 21:46:52 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:33:56 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -96,11 +96,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:41:20 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -149,6 +149,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:41:20 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -51,11 +51,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:34:06 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=smc&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=smc&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -104,6 +104,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 08:50:39 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:26 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:27 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=sdaff&location=94403&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=sdaff&location=94403&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -113,6 +113,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:27 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:28 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:29 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=clinic&location=94403&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=clinic&location=94403&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -118,13 +118,13 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.6741946265175476],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:29 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:27 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:27 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -113,6 +113,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:27 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/with_keyword_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:30 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:30 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -149,12 +149,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -169,6 +169,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.028199336,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:31 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/with_location_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_location_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:29 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:30 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=asdfg&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=asdfg&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -105,11 +105,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:30 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
+    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
     body:
       encoding: US-ASCII
       string: ''
@@ -158,6 +158,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:30 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/results_page_search/with_location_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_location_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -27,8 +27,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:27 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -56,15 +56,15 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:28 GMT
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -89,8 +89,8 @@ http_interactions:
       Date:
       - Thu, 17 Apr 2014 09:43:28 GMT
       Link:
-      - <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=6&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=6&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=2&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -124,13 +124,13 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-16T19:51:30.911-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.6741946265175476],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 09:43:28 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/search_results_map/none_of_the_results_have_coordinates/does_not_display_a_results_list_map.yml
+++ b/spec/cassettes/search_results_map/none_of_the_results_have_coordinates/does_not_display_a_results_list_map.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Location%20with%20no%20phone
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Location%20with%20no%20phone
     body:
       encoding: US-ASCII
       string: ''
@@ -48,9 +48,9 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"id":"21","organization":{"id":7,"name":"Location with no phone","slug":"location-with-no-phone","created_at":"2014-04-16T19:51:31.330-07:00","updated_at":"2014-04-16T19:51:31.516-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"},"services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"updated_at":"2014-04-16T19:51:31.443-07:00","mail_address":{"id":21,"location_id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
+      string: '[{"id":"21","organization":{"id":7,"name":"Location with no phone","slug":"location-with-no-phone","created_at":"2014-04-16T19:51:31.330-07:00","updated_at":"2014-04-16T19:51:31.516-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"},"services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"updated_at":"2014-04-16T19:51:31.443-07:00","mail_address":{"id":21,"location_id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
         phone","name":"Location with no phone","created_at":"2014-04-16T19:51:31.376-07:00","slug":"location-with-no-phone","short_desc":"no
-        phone","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091376],"highlight":null,"_explanation":null}]'
-    http_version: 
+        phone","url":"http://ohana-api-test.herokuapp.com/api/locations/21","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091376],"highlight":null,"_explanation":null}]'
+    http_version:
   recorded_at: Thu, 17 Apr 2014 04:12:14 GMT
 recorded_with: VCR 2.8.0

--- a/spec/cassettes/search_results_map/results_have_entries_that_have_coordinates/displays_a_results_list_map.yml
+++ b/spec/cassettes/search_results_map/results_have_entries_that_have_coordinates/displays_a_results_list_map.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-demo.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations
     body:
       encoding: US-ASCII
       string: ''
@@ -50,13 +50,13 @@ http_interactions:
       encoding: UTF-8
       string: '[{"services":[{"id":23,"service_areas":["San Mateo County"],"updated_at":"2014-04-16T19:51:31.986-07:00"}],"hours":"Monday-Friday
         10am-5pm","urls":["http://codeforamerica.org"],"emails":["eml@example.org"],"transportation":"SAMTRANS
-        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-demo.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
-        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
+        stops within 1/2 mile.","short_desc":"This is a short description","url":"http://ohana-api-test.herokuapp.com/api/locations/22","kind":"Test","phones":[{"id":22,"location_id":22,"number":"7035551212","department":"CalFresh","extension":"x1223","vanity_number":"703555-ABCD"}],"contacts":[{"id":29,"location_id":22,"name":"Moncef","title":"Director"}],"id":"22","organization":{"id":8,"name":"Admin
+        Test Org","slug":"admin-test-org","created_at":"2014-04-16T19:51:31.573-07:00","updated_at":"2014-04-16T19:51:32.099-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-16T19:51:31.995-07:00","faxes":[{"id":21,"location_id":22,"number":"2025551212","department":"CalFresh"}],"address":{"id":21,"location_id":22,"street":"bozo","city":"fairfax","state":"va","zip":"12345"},"description":"This
         is a description","name":"Admin Test Location","created_at":"2014-04-16T19:51:31.649-07:00","slug":"admin-test-location","longitude":-73.9395687,"latitude":42.8142432,"coordinates":[-73.9395687,42.8142432],"accessibility":["Elevator","Disabled
         Restroom"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091649],"highlight":null,"_explanation":null},{"id":"21","organization":{"id":7,"name":"Location
-        with no phone","slug":"location-with-no-phone","created_at":"2014-04-16T19:51:31.330-07:00","updated_at":"2014-04-16T19:51:31.516-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/7/locations"},"services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"updated_at":"2014-04-16T19:51:31.443-07:00","mail_address":{"id":21,"location_id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
+        with no phone","slug":"location-with-no-phone","created_at":"2014-04-16T19:51:31.330-07:00","updated_at":"2014-04-16T19:51:31.516-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/7","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/7/locations"},"services":[{"id":22,"updated_at":"2014-04-16T19:51:31.433-07:00"}],"updated_at":"2014-04-16T19:51:31.443-07:00","mail_address":{"id":21,"location_id":21,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
         phone","name":"Location with no phone","created_at":"2014-04-16T19:51:31.376-07:00","slug":"location-with-no-phone","short_desc":"no
-        phone","url":"http://ohana-api-demo.herokuapp.com/api/locations/21","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091376],"highlight":null,"_explanation":null},{"services":[{"id":21,"eligibility":"Low-income
+        phone","url":"http://ohana-api-test.herokuapp.com/api/locations/21","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397703091376],"highlight":null,"_explanation":null},{"services":[{"id":21,"eligibility":"Low-income
         person without access to health care","fees":"None.","how_to_apply":"Call
         for screening appointment (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
         City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
@@ -64,9 +64,9 @@ http_interactions:
         Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
         9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-demo.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
+        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/20","phones":[{"id":21,"location_id":20,"number":"650
         578-0400"}],"contacts":[{"id":28,"location_id":20,"name":"Sharon Petersen","title":"Administrator"}],"id":"20","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:31.212-07:00","faxes":[{"id":20,"location_id":20,"number":"650
         578-0440"}],"address":{"id":20,"location_id":20,"street":"19 West 39th Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
         dental care to those in need. Offers basic medical care for adults.","name":"San
@@ -78,9 +78,9 @@ http_interactions:
         City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
         9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
         stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-demo.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
+        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":20,"location_id":19,"number":"650
         839-1447"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":6,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
+        House","slug":"samaritan-house","created_at":"2014-04-16T19:51:30.412-07:00","updated_at":"2014-04-16T19:51:31.275-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"updated_at":"2014-04-16T19:51:30.771-07:00","faxes":[{"id":19,"location_id":19,"number":"650
         839-1457"}],"address":{"id":19,"location_id":19,"street":"114 Fifth Avenue","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides free medical care
         to those in need. Offers basic medical exams for adults and tuberculosis screening.
@@ -100,9 +100,9 @@ http_interactions:
         9-4:30","urls":["http://www.tsagoldenstate.org"],"transportation":"SAMTRANS
         stops within 1 block, BART stops within 3 blocks.","short_desc":"Provides
         emergency food and clothing and furniture vouchers to low-income families
-        in times of crisis.","url":"http://ohana-api-demo.herokuapp.com/api/locations/18","phones":[{"id":19,"location_id":18,"number":"650
+        in times of crisis.","url":"http://ohana-api-test.herokuapp.com/api/locations/18","phones":[{"id":19,"location_id":18,"number":"650
         266-4591"}],"contacts":[{"id":26,"location_id":18,"name":"Kenneth Gibson","title":"Major"}],"id":"18","organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:30.291-07:00","faxes":[{"id":17,"location_id":18,"number":"650
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:30.291-07:00","faxes":[{"id":17,"location_id":18,"number":"650
         266-2594"},{"id":18,"location_id":18,"number":"650 266-4594"}],"address":{"id":18,"location_id":18,"street":"409
         South Spruce Avenue","city":"South San Francisco","state":"CA","zip":"94080"},"description":"Provides
         emergency food, clothing and furniture vouchers to low-income families in
@@ -124,10 +124,10 @@ http_interactions:
         Army","street":"P.O. Box 61868","city":"Sunnyvale","state":"CA","zip":"94088"},"hours":"Monday-Friday,
         9-4","emails":["william_nichols@usw.salvationarmy.org"],"transportation":"VTA
         stops within 4 blocks.","short_desc":"Provides emergency assistance to persons
-        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-demo.herokuapp.com/api/locations/17","phones":[{"id":18,"location_id":17,"number":"408
+        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-test.herokuapp.com/api/locations/17","phones":[{"id":18,"location_id":17,"number":"408
         720-0420"}],"contacts":[{"id":25,"location_id":17,"name":"James Lee","title":"Commanding
         Officer"}],"id":"17","languages":["Korean"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.861-07:00","faxes":[{"id":16,"location_id":17,"number":"408
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.861-07:00","faxes":[{"id":16,"location_id":17,"number":"408
         720-8075"}],"address":{"id":17,"location_id":17,"street":"1161 South Bernardo","city":"Sunnyvale","state":"CA","zip":"94087"},"description":"Provides
         emergency assistance including food and clothing for persons in immediate
         need. Provides PG\u0026E assistance through REACH program. Youth programs
@@ -144,9 +144,9 @@ http_interactions:
         SERVICES","Residential Care","DRUG ABUSE SERVICES"],"updated_at":"2014-04-16T19:51:29.478-07:00"}],"mail_address":{"id":16,"location_id":16,"attention":"Adult
         Rehabilitation Center","street":"1500 Valencia Street","city":"San Francisco","state":"CA","zip":"94110"},"hours":"Monday-Friday,
         8-4","transportation":"MUNI - 26 Valencia, Mission Street lines.","short_desc":"Long-term
-        (6-12 month) residential treatment program for men/women age 21-60.","url":"http://ohana-api-demo.herokuapp.com/api/locations/16","phones":[{"id":17,"location_id":16,"number":"415
+        (6-12 month) residential treatment program for men/women age 21-60.","url":"http://ohana-api-test.herokuapp.com/api/locations/16","phones":[{"id":17,"location_id":16,"number":"415
         643-8000"}],"contacts":[{"id":24,"location_id":16,"name":"Jack Phillips","title":"Administrator"}],"id":"16","languages":["Spanish"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.487-07:00","faxes":[{"id":15,"location_id":16,"number":"415
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.487-07:00","faxes":[{"id":15,"location_id":16,"number":"415
         285-1391"}],"address":{"id":16,"location_id":16,"street":"1500 Valencia Street","city":"San
         Francisco","state":"CA","zip":"94110"},"description":"Provides a long-term
         (6-12 month) residential rehabilitation program for men and women with substance
@@ -171,10 +171,10 @@ http_interactions:
         Deposit Assistance","Utility Service Payment Assistance"],"updated_at":"2014-04-16T19:51:29.058-07:00"}],"mail_address":{"id":15,"location_id":15,"attention":"Salvation
         Army","street":"P.O. Box 1147","city":"Redwood City","state":"CA","zip":"94064"},"urls":["http://www.tsagoldenstate.org"],"transportation":"SAMTRANS
         stops nearby.","short_desc":"Provides a variety of emergency services to low-income
-        persons. Also sponsors recreational and educational activities.","url":"http://ohana-api-demo.herokuapp.com/api/locations/15","phones":[{"id":16,"location_id":15,"number":"650
+        persons. Also sponsors recreational and educational activities.","url":"http://ohana-api-test.herokuapp.com/api/locations/15","phones":[{"id":16,"location_id":15,"number":"650
         368-4643"}],"contacts":[{"id":23,"location_id":15,"name":"Andres Espinoza","title":"Captain,
         Commanding Officer"}],"id":"15","languages":["Spanish"],"organization":{"id":5,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.067-07:00","faxes":[{"id":14,"location_id":15,"number":"650
+        Army","slug":"salvation-army","created_at":"2014-04-16T19:51:28.768-07:00","updated_at":"2014-04-16T19:51:30.355-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-16T19:51:29.067-07:00","faxes":[{"id":14,"location_id":15,"number":"650
         364-1712"}],"address":{"id":15,"location_id":15,"street":"660 Veterans Blvd.","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"Provides food, clothing,
         bus tokens and shelter to individuals and families in times of crisis from
@@ -190,9 +190,9 @@ http_interactions:
         wait.","funding_sources":["City"],"service_areas":["San Mateo County"],"keywords":["EDUCATION
         SERVICES","Library","Libraries","Public Libraries"],"updated_at":"2014-04-16T19:51:28.610-07:00"}],"mail_address":{"id":14,"location_id":14,"attention":"Redwood
         Shores Branch","street":"399 Marine Parkway","city":"Redwood City","state":"CA","zip":"94065"},"urls":["http://www.redwoodcity.org/library"],"short_desc":"Provides
-        general reading materials and reference services.","url":"http://ohana-api-demo.herokuapp.com/api/locations/14","phones":[{"id":15,"location_id":14,"number":"650
+        general reading materials and reference services.","url":"http://ohana-api-test.herokuapp.com/api/locations/14","phones":[{"id":15,"location_id":14,"number":"650
         780-5740"}],"contacts":[{"id":22,"location_id":14,"name":"Dave Genesy","title":"Library
-        Director"}],"id":"14","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.623-07:00","address":{"id":14,"location_id":14,"street":"399
+        Director"}],"id":"14","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.623-07:00","address":{"id":14,"location_id":14,"street":"399
         Marine Parkway.","city":"Redwood City","state":"CA","zip":"94065"},"description":"Provides
         general reading materials, including large-type books, videos, music cassettes
         and CDs, and books on tape. Offers children''s programs and a Summer Reading
@@ -208,9 +208,9 @@ http_interactions:
         Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-8:30; Friday, 10-5","urls":["http://www.projectreadredwoodcity.org"],"emails":["rclread@redwoodcity.org"],"transportation":"SAMTRANS
         stops within 1 block.","short_desc":"Offers an intergenerational literacy
-        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-demo.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
+        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-test.herokuapp.com/api/locations/13","phones":[{"id":14,"location_id":13,"number":"650
         780-7077"}],"contacts":[{"id":21,"location_id":13,"name":"Kathy Endaya","title":"Director"}],"id":"13","organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:28.228-07:00","faxes":[{"id":13,"location_id":13,"number":"650
         780-7004"}],"address":{"id":13,"location_id":13,"street":"1044 Middlefield
         Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"description":"Offers
         an intergenerational literacy program for youth and English-speaking adults
@@ -230,10 +230,10 @@ http_interactions:
         SERVICES","Library","Libraries","Public Libraries"],"updated_at":"2014-04-16T19:51:27.847-07:00"}],"mail_address":{"id":12,"location_id":12,"attention":"Schaberg
         Branch","street":"2140 Euclid Avenue","city":"Redwood City","state":"CA","zip":"94061"},"hours":"Tuesday-Thursday,
         1-6, Saturday, 10-3","transportation":"SAMTRANS stops within 1 block.","short_desc":"Provides
-        general reading materials and reference services.","url":"http://ohana-api-demo.herokuapp.com/api/locations/12","phones":[{"id":13,"location_id":12,"number":"650
+        general reading materials and reference services.","url":"http://ohana-api-test.herokuapp.com/api/locations/12","phones":[{"id":13,"location_id":12,"number":"650
         780-7010"}],"contacts":[{"id":19,"location_id":12,"name":"Dave Genesy","title":"Library
         Director"},{"id":20,"location_id":12,"name":"Elizabeth Meeks","title":"Branch
-        Manager"}],"id":"12","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.856-07:00","faxes":[{"id":12,"location_id":12,"number":"650
+        Manager"}],"id":"12","organization":{"id":4,"name":"Redwood City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.856-07:00","faxes":[{"id":12,"location_id":12,"number":"650
         365-3738"}],"address":{"id":12,"location_id":12,"street":"2140 Euclid Avenue.","city":"Redwood
         City","state":"CA","zip":"94061"},"description":"Provides general reading
         materials, including large-type books, DVD''s and CDs, books on CD and some
@@ -247,11 +247,11 @@ http_interactions:
         Library","street":"1044 Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-9; Friday, Saturday, 10-5; Sunday, 12-5","urls":["http://www.redwoodcity.org/library"],"emails":["rclinfo@redwoodcity.org"],"transportation":"SAMTRANS
         stops within 1 block; CALTRAIN stops within 1 block.","short_desc":"Provides
-        general reference and reading materials to adults, teenagers and children.","url":"http://ohana-api-demo.herokuapp.com/api/locations/11","phones":[{"id":12,"location_id":11,"number":"650
+        general reference and reading materials to adults, teenagers and children.","url":"http://ohana-api-test.herokuapp.com/api/locations/11","phones":[{"id":12,"location_id":11,"number":"650
         780-7018","department":"Circulation"}],"contacts":[{"id":17,"location_id":11,"name":"Dave
         Genesy","title":"Library Director"},{"id":18,"location_id":11,"name":"Maria
         Kramer","title":"Library Division Manager"}],"id":"11","languages":["Spanish"],"organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.441-07:00","faxes":[{"id":11,"location_id":11,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.441-07:00","faxes":[{"id":11,"location_id":11,"number":"650
         780-7069"}],"address":{"id":11,"location_id":11,"street":"1044 Middlefield
         Road","city":"Redwood City","state":"CA","zip":"94063"},"description":"Provides
         general reading and media materials, literacy and homework assistance, and
@@ -271,11 +271,11 @@ http_interactions:
         Libraries"],"updated_at":"2014-04-16T19:51:26.997-07:00"}],"mail_address":{"id":10,"location_id":10,"attention":"Fair
         Oaks Branch","street":"2510 Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
         10-7; Friday, 10-5","transportation":"SAMTRANS stops in front.","short_desc":"Provides
-        general reading materials and reference services.","url":"http://ohana-api-demo.herokuapp.com/api/locations/10","phones":[{"id":11,"location_id":10,"number":"650
+        general reading materials and reference services.","url":"http://ohana-api-test.herokuapp.com/api/locations/10","phones":[{"id":11,"location_id":10,"number":"650
         780-7261"}],"contacts":[{"id":15,"location_id":10,"name":"Dave Genesy","title":"Library
         Director"},{"id":16,"location_id":10,"name":"Maria Kramer","title":"Library
         Divisions Manager"}],"id":"10","languages":["Spanish"],"organization":{"id":4,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.006-07:00","faxes":[{"id":10,"location_id":10,"number":"650
+        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-16T19:51:26.651-07:00","updated_at":"2014-04-16T19:51:28.690-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-16T19:51:27.006-07:00","faxes":[{"id":10,"location_id":10,"number":"650
         569-3371"}],"address":{"id":10,"location_id":10,"street":"2510 Middlefield
         Road","city":"Redwood City","state":"CA","zip":"94063"},"description":"Provides
         general reading material, including bilingual, multi-cultural books, CDs and
@@ -294,11 +294,11 @@ http_interactions:
         times: Monday-Friday, 9-1:30","urls":["http://www.peninsulavolunteers.org"],"emails":["mbaker-venturini@peninsulavolunteers.org"],"transportation":"Not
         necessary for service.","short_desc":"Will deliver a hot meal to the home
         of persons age 60 or over who are homebound and unable to prepare their own
-        meals. Can provide special diets.","url":"http://ohana-api-demo.herokuapp.com/api/locations/9","phones":[{"id":10,"location_id":9,"number":"650
+        meals. Can provide special diets.","url":"http://ohana-api-test.herokuapp.com/api/locations/9","phones":[{"id":10,"location_id":9,"number":"650
         323-2022"}],"contacts":[{"id":12,"location_id":9,"name":"Marilyn Baker-Venturini","title":"Director"},{"id":13,"location_id":9,"name":"Graciela
         Hernandez","title":"Assistant Manager"},{"id":14,"location_id":9,"name":"Julie
         Avelino","title":"Assessment Specialist"}],"id":"9","languages":["Spanish"],"organization":{"id":3,"name":"Peninsula
-        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.487-07:00","faxes":[{"id":9,"location_id":9,"number":"650
+        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.487-07:00","faxes":[{"id":9,"location_id":9,"number":"650
         326-9547"}],"address":{"id":9,"location_id":9,"street":"800 Middle Avenue","city":"Menlo
         Park","state":"CA","zip":"94025-9881"},"description":"Delivers a hot meal
         to the home of persons age 60 or over who are primarily homebound and unable
@@ -321,11 +321,11 @@ http_interactions:
         House","street":"500 Arbor Road","city":"Menlo Park","state":"CA","zip":"94025"},"hours":"Monday-Friday,
         8-5:30","urls":["http://www.penvol.org/rosenerhouse"],"emails":["bkalt@peninsulavolunteers.org","fmarchick@peninsulavolunteers.org"],"transportation":"Transportation
         can be arranged via Redi-Wheels or Outreach.","short_desc":"A day center for
-        adults age 50 or over.","url":"http://ohana-api-demo.herokuapp.com/api/locations/8","phones":[{"id":9,"location_id":8,"number":"650
+        adults age 50 or over.","url":"http://ohana-api-test.herokuapp.com/api/locations/8","phones":[{"id":9,"location_id":8,"number":"650
         322-0126"}],"contacts":[{"id":10,"location_id":8,"name":"Bart Charlow","title":"Executive
         Director, Peninsula Volunteers"},{"id":11,"location_id":8,"name":"Barbara
         Kalt","title":"Director"}],"id":"8","languages":["Spanish","Filipino (Tagalog)","Vietnamese"],"organization":{"id":3,"name":"Peninsula
-        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.018-07:00","faxes":[{"id":8,"location_id":8,"number":"650
+        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:26.018-07:00","faxes":[{"id":8,"location_id":8,"number":"650
         322-4067"}],"address":{"id":8,"location_id":8,"street":"500 Arbor Road","city":"Menlo
         Park","state":"CA","zip":"94025"},"description":"Rosener House is a day center
         for older adults who may be unable to live independently but do not require
@@ -359,11 +359,11 @@ http_interactions:
         House","street":"800 Middle Avenue","city":"Menlo Park","state":"CA","zip":"94025-9881"},"hours":"Monday-Thursday,
         8 am-9 pm; Friday, 8-5","urls":["http://www.penvol.org/littlehouse"],"emails":["polson@peninsulavolunteers.org"],"transportation":"SAMTRANS
         stops within 3 blocks, RediWheels and Menlo Park Shuttle stop at door.","short_desc":"A
-        multipurpose senior citizens'' center.","url":"http://ohana-api-demo.herokuapp.com/api/locations/7","phones":[{"id":8,"location_id":7,"number":"650
+        multipurpose senior citizens'' center.","url":"http://ohana-api-test.herokuapp.com/api/locations/7","phones":[{"id":8,"location_id":7,"number":"650
         326-2025"}],"contacts":[{"id":8,"location_id":7,"name":"Peter Olson","title":"Little
         House Director"},{"id":9,"location_id":7,"name":"Bart Charlow","title":"Executive
         Director, Peninsula Volunteers"}],"id":"7","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":3,"name":"Peninsula
-        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:25.586-07:00","faxes":[{"id":7,"location_id":7,"number":"650
+        Volunteers","slug":"peninsula-volunteers","created_at":"2014-04-16T19:51:25.233-07:00","updated_at":"2014-04-16T19:51:26.601-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-16T19:51:25.586-07:00","faxes":[{"id":7,"location_id":7,"number":"650
         326-9547"}],"address":{"id":7,"location_id":7,"street":"800 Middle Avenue","city":"Menlo
         Park","state":"CA","zip":"94025-9881"},"description":"A multipurpose center
         offering a wide variety of recreational, education and cultural activities.
@@ -394,10 +394,10 @@ http_interactions:
         Mateo County"],"keywords":["COMMUNITY SERVICES","Speakers","Automobile Loans"],"updated_at":"2014-04-16T19:51:25.102-07:00"}],"mail_address":{"id":6,"location_id":6,"attention":"Economic
         Self - Sufficiency Program","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"urls":["http://www.peninsulafamilyservice.org"],"emails":["waystowork@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block. CALTRAIN stops within 6 blocks.","short_desc":"Makes
-        small loans to working families.","url":"http://ohana-api-demo.herokuapp.com/api/locations/6","phones":[{"id":7,"location_id":6,"number":"650
+        small loans to working families.","url":"http://ohana-api-test.herokuapp.com/api/locations/6","phones":[{"id":7,"location_id":6,"number":"650
         403-4300","extension":"4100"}],"contacts":[{"id":7,"location_id":6,"name":"Joe
         Bloom","title":"Financial Empowerment Programs Program Director"}],"id":"6","languages":["Hindi","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:25.113-07:00","faxes":[{"id":6,"location_id":6,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:25.113-07:00","faxes":[{"id":6,"location_id":6,"number":"650
         403-4303"}],"address":{"id":6,"location_id":6,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides fixed 8% short
         term loans to eligible applicants for the purchase of a reliable, used autmobile.
@@ -418,10 +418,10 @@ http_interactions:
         10-6; Tuesday-Friday, 10-8; Saturday, Sunday, 9:30-5:30","urls":["http://www.peninsulafamilyservice.org"],"emails":["kpesavento@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 4 blocks.","short_desc":"Provides
         supervised visitation services and a neutral site for parents in extremely
-        hostile divorces to carry out supervised exchanges of children.","url":"http://ohana-api-demo.herokuapp.com/api/locations/5","phones":[{"id":6,"location_id":5,"number":"650
+        hostile divorces to carry out supervised exchanges of children.","url":"http://ohana-api-test.herokuapp.com/api/locations/5","phones":[{"id":6,"location_id":5,"number":"650
         403-4300","extension":"4500"}],"contacts":[{"id":6,"location_id":5,"name":"Kimberly
         Pesavento","title":"Director of Visitation"}],"id":"5","languages":["Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.690-07:00","faxes":[{"id":5,"location_id":5,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.690-07:00","faxes":[{"id":5,"location_id":5,"number":"650
         403-4303"}],"address":{"id":5,"location_id":5,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides supervised visitation
         services and a neutral site for parents to carry out supervised exchanges
@@ -444,11 +444,11 @@ http_interactions:
         Senior Peer Counseling","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Any
         time that is convenient for the client and peer counselor","transportation":"Service
         is provided in person''s home or at a mutually agreed upon location.","short_desc":"Offers
-        supportive counseling services to older persons.","url":"http://ohana-api-demo.herokuapp.com/api/locations/4","phones":[{"id":5,"location_id":4,"number":"650
+        supportive counseling services to older persons.","url":"http://ohana-api-test.herokuapp.com/api/locations/4","phones":[{"id":5,"location_id":4,"number":"650
         403-4300","department":"English"}],"contacts":[{"id":5,"location_id":4,"name":"Howard
         Lader, LCSW","title":"Manager, Senior Peer Counseling"}],"id":"4","languages":["Chinese
         (Cantonese)","Chinese (Mandarin)","Filipino (Tagalog)","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.268-07:00","faxes":[{"id":4,"location_id":4,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:24.268-07:00","faxes":[{"id":4,"location_id":4,"number":"650
         403-4303"}],"address":{"id":4,"location_id":4,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94403"},"description":"Offers supportive counseling
         services to San Mateo County residents age 55 or over. Volunteer counselors
@@ -473,11 +473,11 @@ http_interactions:
         9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["bbrown@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops within 1 block, CALTRAIN stops within 6 blocks.","short_desc":"Provides
         training and job placement to eligible persons age 55 or over. All persons
-        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-demo.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
+        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-test.herokuapp.com/api/locations/3","phones":[{"id":4,"location_id":3,"number":"650
         403-4300","extension":"Ext. 4385"}],"contacts":[{"id":4,"location_id":3,"name":"Brenda
         Brown","title":"Director, Second Career Services"}],"id":"3","languages":["Chinese
         (Mandarin)","Filipino (Tagalog)","Italian","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.885-07:00","faxes":[{"id":3,"location_id":3,"number":"650
         403-4302"}],"address":{"id":3,"location_id":3,"street":"24 Second Avenue","city":"San
         Mateo","state":"CA","zip":"94401"},"description":"Provides training and job
         placement to eligible people age 55 or over who meet certain income qualifications.
@@ -504,11 +504,11 @@ http_interactions:
         Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
         City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
         stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-demo.herokuapp.com/api/locations/2","phones":[{"id":3,"location_id":2,"number":"650
+        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/2","phones":[{"id":3,"location_id":2,"number":"650
         780-7525"}],"contacts":[{"id":2,"location_id":2,"name":"Susan Houston","title":"Director
         of Older Adult Services"},{"id":3,"location_id":2,"name":"Christina Gonzalez","title":"Center
         Director"}],"id":"2","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":2,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.454-07:00","faxes":[{"id":2,"location_id":2,"number":"650
+        Family Service","slug":"peninsula-family-service","created_at":"2014-04-16T19:51:22.599-07:00","updated_at":"2014-04-16T19:51:25.176-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"},"updated_at":"2014-04-16T19:51:23.454-07:00","faxes":[{"id":2,"location_id":2,"number":"650
         701-0856"}],"address":{"id":2,"location_id":2,"street":"2600 Middlefield Road","city":"Redwood
         City","state":"CA","zip":"94063"},"description":"A walk-in center for older
         adults that provides social services, wellness, recreational, educational
@@ -571,12 +571,12 @@ http_interactions:
         Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
         8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
         stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-demo.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
         372-6200","department":"Information"},{"id":2,"location_id":1,"number":"650
         372-6200","department":"Reservations"}],"contacts":[{"id":1,"location_id":1,"name":"Suzanne
         Badenhoop","title":"Board President"}],"id":"1","languages":["Chinese (Cantonese)","Chinese
         (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":1,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-demo.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-demo.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-16T19:48:29.197-07:00","updated_at":"2014-04-16T19:48:31.335-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-16T19:48:31.128-07:00","faxes":[{"id":1,"location_id":1,"number":"650
         627-8244"}],"address":{"id":1,"location_id":1,"street":"2013 Avenue of the
         fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -591,6 +591,6 @@ http_interactions:
         in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
         Agency","created_at":"2014-04-16T19:48:29.958-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397702909958],"highlight":null,"_explanation":null}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 Apr 2014 03:59:34 GMT
 recorded_with: VCR 2.8.0

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -22,14 +22,14 @@ describe StatusController do
       end
 
       it "returns API failure error" do
-        stub_request(:get, "http://ohana-api-demo.herokuapp.com/api/locations/san-mateo-free-medical-clinic?api_token=#{ENV["OHANA_API_TOKEN"]}").
+        stub_request(:get, "http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic?api_token=#{ENV["OHANA_API_TOKEN"]}").
           with(:headers => {'Accept'=>'application/vnd.ohanapi-v1+json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0',
             'X-Api-Token'=>"#{ENV["OHANA_API_TOKEN"]}"}).
           to_return(:status => 200, :body => "", :headers => {})
 
-        stub_request(:get, "http://ohana-api-demo.herokuapp.com/api/search?api_token=#{ENV["OHANA_API_TOKEN"]}&keyword=maceo").
+        stub_request(:get, "http://ohana-api-test.herokuapp.com/api/search?api_token=#{ENV["OHANA_API_TOKEN"]}&keyword=maceo").
           with(:headers => {'Accept'=>'application/vnd.ohanapi-v1+json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ def stub_get(url)
 end
 
 def ohanapi_url(url)
-  url =~ /^http/ ? url : "http://ohana-api-demo.herokuapp.com/api#{url}"
+  url =~ /^http/ ? url : "http://ohana-api-test.herokuapp.com/api#{url}"
 end
 
 def fixture_path


### PR DESCRIPTION
This PR basically just updates the specs to point to ohana-api-test

I created a new instance of the API on Heroku to use with specs so that we can let others play with ohana-api-demo without affecting the tests. Also, ohana-api-test defaults to 1 result per page, but I want to change ohana-api-demo to use 30 by default. This PR needs to merged first though.
