### PR TITLE
Fixes #377 - adds check for global GA object

### DIFF
--- a/app/assets/javascripts/app/google-analytics-manager.js
+++ b/app/assets/javascripts/app/google-analytics-manager.js
@@ -9,7 +9,7 @@ define(function() {
   // to these elements that register the element with google analytics.
   function init()
   {
-    if (window._gaq.length > 0)
+    if (window._gaq && window._gaq.length > 0)
     {
       var toTrack = document.querySelectorAll("*[data-gaq]");
       var item;
@@ -21,6 +21,7 @@ define(function() {
     }
   }
 
+  // PRIVATE METHODS
   function _track(evt)
   {
     var item = evt.currentTarget;


### PR DESCRIPTION
Global Google Analytics object wasn’t being initialized outside of
production, which caused an error that stopped other JS modules from
loading. This commit adds a check in the google-analytics-manager
script to check for the existence of the _gaq global object, before
doing initialization of Google Analytics settings.
