### PR TITLE
Fixes #378 - adds !important to fallback CSS

### DIFF
--- a/app/views/component/organizations/results/_map_view.html.haml
+++ b/app/views/component/organizations/results/_map_view.html.haml
@@ -16,4 +16,4 @@
     %noscript
       %style>
         -# hides map when JS is disabled
-        = "#map-view {display:none;}"
+        = "#map-view {display:none !important;}"


### PR DESCRIPTION
Fallback CSS for the map-view turned the display to none, but could be
overridden in other styles. This adds !important to override any other
style settings.
