### PR TITLE
Fixes #387 - removes duplicate summary

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -1474,45 +1474,6 @@ body { top: 0px !important; }
 
 #results-entries
 {
-  #search-summary-container
-  {
-    @include background( linear-gradient(left,lightest($yellow),$white) );
-  }
-
-  #search-summary
-  {
-    font-family: $font_san_serif;
-    @include type-size(baseline);
-    padding: 10px;
-    padding-left: 20px;
-
-    strong
-    {
-      font-weight: bold;
-    }
-
-    div:first-child
-    {
-      margin-right: 20px;
-    }
-
-    div
-    {
-      @include inline-block();
-      .fa
-      {
-        color: $greyscale_midtone;
-      }
-      em
-      {
-        color: $greyscale_midtone;
-      }
-      em > strong
-      {
-        color: $black;
-      }
-    }
-  }
 
   > ul
   {
@@ -1897,13 +1858,6 @@ body { top: 0px !important; }
 #map-view
 {
   background: $white;
-  #search-summary
-  {
-    border-bottom: 0;
-    @include inline-block();
-    border-left: 1px solid $greyscale_light; // IE fallback
-    border-left: 1px solid rgba($black,.1);
-  }
 }
 
 #map-canvas

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -366,13 +366,6 @@
         margin-right: 15px;
       }
 
-      #search-summary-container
-      {
-        background: lightest($yellow);
-        border-bottom: 1px solid $greyscale_midtone; // IE fallback
-        border-bottom: 1px solid rgba($black,.1);
-      }
-
       #map-view-control
       {
         padding-left: 20px;

--- a/app/views/component/organizations/results/_body.html.haml
+++ b/app/views/component/organizations/results/_body.html.haml
@@ -8,18 +8,10 @@
   - if @orgs.present?
     - if @map_data.present?
       = render 'component/organizations/results/map_view'
-    - else
-      -# title attr. is used to retrieve content for document title in JS
-      %p#search-summary{:title=>"#{@search_summary_plain}"}
-        = @search_summary_html
 
     = render 'component/organizations/results/list_view'
   - else
     %section.no-results
-      -# title attr. is used to retrieve content for document title in JS
-      %p#search-summary{:title=>"#{@search_summary_plain}"}
-        = @search_summary_html
-
       %div.message
         %strong Unfortunately, your search returned no results.
         %em If you have trouble finding what you're looking for, try:

--- a/spec/cassettes/Search_summary/when_visiting_search_results_page_that_does_not_have_results.yml
+++ b/spec/cassettes/Search_summary/when_visiting_search_results_page_that_does_not_have_results.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfdsggfdg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      X-Api-Token:
+      - "<API_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 29 Apr 2014 04:29:30 GMT
+      Etag:
+      - '"d751713988987e9331980363e24189ce"'
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfdsggfdg&page=0>;
+        rel="last"
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      Status:
+      - 200 OK
+      X-Powered-By:
+      - Phusion Passenger 4.0.40
+      X-Request-Id:
+      - 4f169b91-a75e-4627-baee-adc5b01f216e
+      X-Runtime:
+      - '0.017673'
+      X-Total-Count:
+      - '0'
+      X-Total-Pages:
+      - '0'
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Tue, 29 Apr 2014 04:29:29 GMT
+recorded_with: VCR 2.9.0

--- a/spec/cassettes/Search_summary/when_visiting_search_results_page_that_has_results.yml
+++ b/spec/cassettes/Search_summary/when_visiting_search_results_page_that_has_results.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      X-Api-Token:
+      - "<API_TOKEN>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 29 Apr 2014 04:29:30 GMT
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      Status:
+      - 200 OK
+      X-Current-Page:
+      - '1'
+      X-Powered-By:
+      - Phusion Passenger 4.0.40
+      X-Request-Id:
+      - 606b90cb-ca67-45d5-ab12-baefa6778bc8
+      X-Runtime:
+      - '0.306666'
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
+        the public, military facilities, schools and government entities","description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
+        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
+        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
+        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
+        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
+        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
+        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
+        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
+        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
+        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
+        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
+        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
+        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
+        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
+        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
+        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
+        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
+        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+    http_version: 
+  recorded_at: Tue, 29 Apr 2014 04:29:29 GMT
+recorded_with: VCR 2.9.0

--- a/spec/features/search/search_summary_spec.rb
+++ b/spec/features/search/search_summary_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+# Checks for the search results summary
+feature 'Search summary' do
+
+  scenario 'when visiting search results page that has results', :vcr do
+    search_for_maceo
+    # Expect only static and floating search results summary,
+    # and expect that they're only in the results-header.
+    expect(all('.search-summary', :text=>'Displaying 1 result').count).to eq(2)
+    expect(all('.results-header .search-summary', :text=>'Displaying 1 result').count).to eq(2)
+  end
+
+  scenario 'when visiting search results page that does not have results', :vcr do
+    search_for_no_results
+    # Expect only static and floating search results summary,
+    # and expect that they're only in the results-header.
+    expect(all('.search-summary', :text=>'No results').count).to eq(2)
+    expect(all('.results-header .search-summary', :text=>'No results').count).to eq(2)
+  end
+
+end


### PR DESCRIPTION
The search results summary was duplicated on the no results page. This
adds a search results summary test and removes the duplicate, as well
as the associated styles.
