### PR TITLE
Fixes #335 - styles geolocation button.

### DIFF
--- a/app/assets/javascripts/app/location-manager.js
+++ b/app/assets/javascripts/app/location-manager.js
@@ -59,7 +59,7 @@ define(['util/geolocation','app/alert-manager','async!https://maps.googleapis.co
       if (status === google.maps.GeocoderStatus.OK && results[0])
       {
         _locationValue.value = results[0].formatted_address;
-        document.getElementById('location-form').submit();
+        document.getElementById('search-form').submit();
       }
       else
       {

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -707,9 +707,8 @@ sup
   background: midtone($blue); // IE fallback
   background: midtone($blue,.9);
   padding: 10px;
-  min-height: 38px;
   padding-right: 25px;
-  padding-bottom: 24px;
+  padding-bottom: 20px;
   text-align: right;
 
   ul
@@ -740,10 +739,10 @@ body { top: 0px !important; }
   background: midtone($blue); // IE fallback
   background: rgba(midtone($blue), .9);
   border-bottom: 2px solid dark($blue);
-  padding: 21px;
+  padding: 10px;
   padding-right: 25px;
   text-align: right;
-  min-height: 43px;
+  min-height: 40px;
 }
 
 //=================================================================================
@@ -917,6 +916,11 @@ body { top: 0px !important; }
 #geolocate-box
 {
   margin-top: 5px;
+}
+.home #geolocate-box
+{
+  position: absolute;
+  right: 0;
 }
 
 .inside fieldset

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -141,6 +141,12 @@
   // home screen styles
   .home
   {
+
+    #geolocate-box
+    {
+      position: static;
+    }
+
     main
     {
       position: static;
@@ -180,6 +186,8 @@
 
       > div
       {
+        min-height: 165px;
+
         padding: 20px;
         > section
         {

--- a/app/views/component/search/_aside.html.haml
+++ b/app/views/component/search/_aside.html.haml
@@ -29,4 +29,3 @@
           Clear filters
 
     = render :partial => 'component/search/options'
-

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -1,22 +1,24 @@
 = form_tag('/organizations', :method => :get, :id=>"search-form") do
   %section#search-box
     %div
-      %section#keyword-search-box>
-        %label{:for => "keyword"}
-          I need...
-        %div.input-search-big
-          = search_field_tag :keyword, params[:keyword], :placeholder => "what are you looking for?", :list => "search-keywords"
+      %div
+        %section#keyword-search-box>
+          %label{:for => "keyword"}
+            I need...
+          %div.input-search-big
+            = search_field_tag :keyword, params[:keyword], :placeholder => "what are you looking for?", :list => "search-keywords"
 
-          -#
-            - cache ['keywords-list', *cip_keywords] do
-              %datalist#search-keywords
-                <!--[if IE 8]><select disabled style="display:none"><![endif]-->
-                - cip_keywords.each do |keyword|
-                  %option{:value=>keyword}
-                    = keyword
-                <!--[if IE 8]> </select> <![endif]-->
-          = hidden_field_tag "service_area", ""
+            -#
+              - cache ['keywords-list', *cip_keywords] do
+                %datalist#search-keywords
+                  <!--[if IE 8]><select disabled style="display:none"><![endif]-->
+                  - cip_keywords.each do |keyword|
+                    %option{:value=>keyword}
+                      = keyword
+                  <!--[if IE 8]> </select> <![endif]-->
+            = hidden_field_tag "service_area", ""
 
-          %button{:type=>'submit',:id=>'find-btn', :title=>"Search"}
-            %i{:class=>"fa fa-search"}
-            %span Search
+            %button{:type=>'submit',:id=>'find-btn', :title=>"Search"}
+              %i{:class=>"fa fa-search"}
+              %span Search
+        = render :partial => 'component/search/geolocate'

--- a/app/views/component/search/_filter.html.haml
+++ b/app/views/component/search/_filter.html.haml
@@ -92,6 +92,6 @@
 
     - if css_field == "location"
       %div#geolocate-box
-        %button#locate-btn.hide.button-medium{:type=>'button'}
+        %button#locate-btn.hide.button-small{:type=>'button'}
           %i{ :class=>"fa fa-map-marker" }
           Services near me

--- a/app/views/component/search/_geolocate.html.haml
+++ b/app/views/component/search/_geolocate.html.haml
@@ -1,6 +1,5 @@
 %div#geolocate-box
-  = form_tag('/organizations', :method => :get, :id=>"location-form") do
-    = hidden_field_tag 'location'
-    %button#locate-btn.hide.button-medium{:type=>'submit'}
-      %i{ :class=>"fa fa-map-marker" }
-      Services near me
+  = hidden_field_tag 'location'
+  %button#locate-btn.hide.button-small{:type=>'submit'}
+    %i{ :class=>"fa fa-map-marker" }
+    Services near me

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -3,5 +3,4 @@
   = render :partial => 'component/search/languages'
   = render :partial => 'component/search/box'
   %section#help-box
-    = render :partial => 'component/search/geolocate'
 = render :partial => 'component/search/category'

--- a/spec/cassettes/homepage_search/when_searching_for_food_stamps_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_food_stamps_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food%20stamps&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food%20stamps&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:07 GMT
+      - Tue, 29 Apr 2014 06:36:40 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&page=5&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&location=&page=5&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 5f65412b-74c9-409f-a077-3e8f852ef3cc
+      - c61036ee-570a-4c29-8572-834bdde70de1
       X-Runtime:
-      - '0.066864'
+      - '0.018128'
       X-Total-Count:
       - '5'
       X-Total-Pages:
@@ -79,5 +79,5 @@ http_interactions:
         clothes and supplies. Offers case management, advocacy and referrals to other
         agencies.","name":"South San Francisco Citadel Corps","created_at":"2014-04-18T12:32:08.969-07:00","longitude":-122.4224905,"slug":"south-san-francisco-citadel-corps","latitude":37.6445898,"coordinates":[-122.4224905,37.6445898],"accessibility":["Wheelchair"],"_score":0.0038341554,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:07 GMT
+  recorded_at: Tue, 29 Apr 2014 06:36:39 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_health_care_reform_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_health_care_reform_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20care%20reform&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20care%20reform&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:05 GMT
+      - Tue, 29 Apr 2014 06:36:35 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&page=10&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&location=&page=10&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,15 +41,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - ef0c0f1a-77d0-45ec-98e9-8fce4cf0d165
+      - e5a73b22-d949-4653-bcfb-9602baff83d5
       X-Runtime:
-      - '0.045064'
+      - '0.032956'
       X-Total-Count:
       - '10'
       X-Total-Pages:
       - '10'
-      Content-Length:
-      - '1132'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -74,5 +74,5 @@ http_interactions:
         City Free Medical Clinic","created_at":"2014-04-18T12:32:09.882-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
         Restroom","Wheelchair"],"_score":0.0060132295,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:05 GMT
+  recorded_at: Tue, 29 Apr 2014 06:36:34 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_sfmnp_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_sfmnp_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:02 GMT
+      - Tue, 29 Apr 2014 06:36:38 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 75fafaf4-65f4-4c64-ac0c-d201b3b7ef1a
+      - d5532c6e-a30d-4c08-839c-6ca8459798d5
       X-Runtime:
-      - '0.047568'
+      - '0.017714'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:02 GMT
+  recorded_at: Tue, 29 Apr 2014 06:36:37 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_wic_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_wic_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:03 GMT
+      - Tue, 29 Apr 2014 06:36:39 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - ed996d11-494e-499b-ae48-bbcb9d5fa580
+      - 315e5ad4-f454-4e8c-90d6-d2d0421db455
       X-Runtime:
-      - '0.027647'
+      - '0.017480'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:03 GMT
+  recorded_at: Tue, 29 Apr 2014 06:36:38 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:04 GMT
+      - Tue, 29 Apr 2014 06:36:36 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 6cede25e-b828-4c44-808b-468c606c1c17
+      - 97e93044-c468-4286-8880-cad260b2db81
       X-Runtime:
-      - '0.026842'
+      - '0.016916'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:04 GMT
+  recorded_at: Tue, 29 Apr 2014 06:36:35 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/less_than_3_pages_in_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/less_than_3_pages_in_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:05 GMT
+      - Tue, 29 Apr 2014 06:34:32 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 3799cbf5-1b1e-4b3a-a52e-ff3fa0ee9229
+      - 9f4919a9-9e8c-4a2e-b262-86c85a3f3bcb
       X-Runtime:
-      - '0.033028'
+      - '0.019693'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,10 +114,10 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:05 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:31 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=3&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=3&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -140,12 +140,12 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:06 GMT
+      - Tue, 29 Apr 2014 06:34:32 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=4&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=4&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -160,9 +160,9 @@ http_interactions:
       X-Previous-Page:
       - '2'
       X-Request-Id:
-      - ed064bfe-8916-4f25-9705-3b3cebb7c049
+      - a78b662e-0922-4eb4-a3f7-0b1e24ea9df4
       X-Runtime:
-      - '0.060028'
+      - '0.022793'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -177,5 +177,5 @@ http_interactions:
         phone","name":"Location with no phone","created_at":"2014-04-18T12:32:12.179-07:00","slug":"location-with-no-phone","short_desc":"no
         phone","url":"http://ohana-api-test.herokuapp.com/api/locations/20","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849532179],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:06 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:31 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/less_than_3_pages_out_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/less_than_3_pages_out_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:01 GMT
+      - Tue, 29 Apr 2014 06:34:30 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - dd4aa0c5-eb9e-41d7-a404-8b27bfdcb521
+      - 94966731-d070-497a-a2ff-0de8734b76bf
       X-Runtime:
-      - '0.041781'
+      - '0.016915'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,10 +114,10 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:01 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:29 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -140,10 +140,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:01 GMT
+      - Tue, 29 Apr 2014 06:34:31 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -156,15 +156,15 @@ http_interactions:
       X-Previous-Page:
       - '21'
       X-Request-Id:
-      - f5f010c2-1004-4814-a408-0fdb0069a127
+      - 83956fa6-b1ce-4628-86fa-9250fd3e6d77
       X-Runtime:
-      - '0.045361'
+      - '0.023635'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1955'
       Connection:
       - keep-alive
     body:
@@ -212,10 +212,10 @@ http_interactions:
         Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849513696],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:01 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:30 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=20&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=20&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -238,12 +238,12 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:02 GMT
+      - Tue, 29 Apr 2014 06:34:31 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=19&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=19&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -258,15 +258,15 @@ http_interactions:
       X-Previous-Page:
       - '19'
       X-Request-Id:
-      - edd594ba-0195-466b-b9d4-52f0a8006aaf
+      - 471d68bd-3505-4112-84df-d11b96daff6e
       X-Runtime:
-      - '0.052901'
+      - '0.028814'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1353'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -299,5 +299,5 @@ http_interactions:
         Formerly known as Family Service Agency of San Mateo County, Senior Peer Counseling.","name":"Senior
         Peer Counseling","created_at":"2014-04-18T12:31:55.530-07:00","longitude":-122.3263232,"slug":"senior-peer-counseling","latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849515530],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:02 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:30 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/more_than_3_pages_in_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/more_than_3_pages_in_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:03 GMT
+      - Tue, 29 Apr 2014 06:34:30 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - b65379e1-e11b-4e8b-aad2-560bb46eaa87
+      - 71302fe3-798a-4897-bbdc-65032e6401c0
       X-Runtime:
-      - '0.030958'
+      - '0.029504'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,10 +114,10 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:03 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:29 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=4&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=4&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -140,12 +140,12 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:03 GMT
+      - Tue, 29 Apr 2014 06:34:30 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=5&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=3&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=5&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -160,15 +160,15 @@ http_interactions:
       X-Previous-Page:
       - '3'
       X-Request-Id:
-      - 7a7ecd57-7f23-43eb-8b2e-2676ee8da497
+      - 5c8ed29f-ecc3-476b-9f32-2d4a3cb19645
       X-Runtime:
-      - '0.037964'
+      - '0.018295'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1015'
       Connection:
       - keep-alive
     body:
@@ -189,5 +189,5 @@ http_interactions:
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849531266],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:04 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:29 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/more_than_3_pages_out_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/more_than_3_pages_out_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:02 GMT
+      - Tue, 29 Apr 2014 06:34:33 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,15 +41,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 48eef082-1c18-4509-aa1a-3d316c254b3f
+      - fa596d7b-99c4-4f32-97aa-60bedd4f9d77
       X-Runtime:
-      - '0.049063'
+      - '0.018123'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
       Content-Length:
-      - '1747'
+      - '1753'
       Connection:
       - keep-alive
     body:
@@ -114,10 +114,10 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:02 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:32 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -140,10 +140,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:02 GMT
+      - Tue, 29 Apr 2014 06:34:33 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -156,15 +156,15 @@ http_interactions:
       X-Previous-Page:
       - '21'
       X-Request-Id:
-      - 358bc449-772c-4bab-9bc0-f81fdea5bff9
+      - 753a8e34-1772-4986-8fa5-a3f56c94d9e7
       X-Runtime:
-      - '0.036769'
+      - '0.015958'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1955'
       Connection:
       - keep-alive
     body:
@@ -212,10 +212,10 @@ http_interactions:
         Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849513696],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:02 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:32 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=18&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=18&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -238,12 +238,12 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:03 GMT
+      - Tue, 29 Apr 2014 06:34:34 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=17&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=19&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=17&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=19&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -258,9 +258,9 @@ http_interactions:
       X-Previous-Page:
       - '17'
       X-Request-Id:
-      - 3d1e16f8-7e31-4333-8cc0-9251ee98bef5
+      - 577b6a8f-a02a-4872-8303-bff8c4b3d233
       X-Runtime:
-      - '0.050782'
+      - '0.042421'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -297,5 +297,5 @@ http_interactions:
         of San Mateo County, Ways to Work Family Loan Program.","name":"Economic Self
         - Sufficiency Program","created_at":"2014-04-18T12:31:57.166-07:00","longitude":-122.3263232,"slug":"economic-self-sufficiency-program","latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849517166],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:03 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:33 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_first_page_with_less_than_4_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_first_page_with_less_than_4_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:05 GMT
+      - Tue, 29 Apr 2014 06:34:31 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 3c84df9d-639b-4dd7-9290-9cde371eff73
+      - 84ce91eb-493c-480e-b66a-79dc533de0e1
       X-Runtime:
-      - '0.023569'
+      - '0.022428'
       X-Total-Count:
       - '3'
       X-Total-Pages:
@@ -82,5 +82,5 @@ http_interactions:
         Read. Call for more information about each service.","name":"Project Read","created_at":"2014-04-18T12:32:03.900-07:00","longitude":-122.227409,"slug":"project-read","latitude":37.4837662,"coordinates":[-122.227409,37.4837662],"accessibility":["Elevator","Ramp","Disabled
         Restroom","Disabled Parking"],"_score":0.010318076,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:05 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:30 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_first_page_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_first_page_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:07 GMT
+      - Tue, 29 Apr 2014 06:34:34 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,15 +41,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 6dd1a643-7d04-467b-82b1-2b532cf8aa12
+      - 70e6c00d-6fef-43b8-8393-5ad92da97f83
       X-Runtime:
-      - '0.074858'
+      - '0.016281'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1747'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -114,5 +114,5 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:07 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:33 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_last_page_with_less_than_4_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_last_page_with_less_than_4_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:06 GMT
+      - Tue, 29 Apr 2014 06:34:32 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 2a1a5fb6-ba46-42c7-9568-fd8a5c3f8e9e
+      - b9f14d19-cda4-4d20-97f6-db28769560e1
       X-Runtime:
-      - '0.067142'
+      - '0.022051'
       X-Total-Count:
       - '3'
       X-Total-Pages:
@@ -82,10 +82,10 @@ http_interactions:
         Read. Call for more information about each service.","name":"Project Read","created_at":"2014-04-18T12:32:03.900-07:00","longitude":-122.227409,"slug":"project-read","latitude":37.4837662,"coordinates":[-122.227409,37.4837662],"accessibility":["Elevator","Ramp","Disabled
         Restroom","Disabled Parking"],"_score":0.010318076,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:06 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:32 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=3&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -108,10 +108,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:06 GMT
+      - Tue, 29 Apr 2014 06:34:33 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -124,9 +124,9 @@ http_interactions:
       X-Previous-Page:
       - '2'
       X-Request-Id:
-      - 04dac362-e3ce-45b7-965b-41c3d6e6322b
+      - 505be81e-b513-42cc-875b-4201ae76da0a
       X-Runtime:
-      - '0.024172'
+      - '0.029721'
       X-Total-Count:
       - '3'
       X-Total-Pages:
@@ -160,5 +160,5 @@ http_interactions:
         Also provides rental assistance when funds are available.","name":"Sunnyvale
         Corps","created_at":"2014-04-18T12:32:08.088-07:00","longitude":-122.0600024,"slug":"sunnyvale-corps","latitude":37.3569004,"coordinates":[-122.0600024,37.3569004],"_score":0.007738203,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:06 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:32 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_last_page_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_last_page_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:04 GMT
+      - Tue, 29 Apr 2014 06:34:35 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 859335d4-f762-4ad7-ade3-837e45d8a260
+      - 36cae2e8-dcb8-4a63-9da2-4632b1717310
       X-Runtime:
-      - '0.054931'
+      - '0.016173'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,10 +114,10 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:04 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:34 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -140,10 +140,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:04 GMT
+      - Tue, 29 Apr 2014 06:34:35 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -156,9 +156,9 @@ http_interactions:
       X-Previous-Page:
       - '21'
       X-Request-Id:
-      - 1ceeac7c-0c4b-4937-8a77-85826a81492d
+      - a6e9315c-7c55-488a-a15b-ce0c34d10c9e
       X-Runtime:
-      - '0.038513'
+      - '0.016863'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -212,5 +212,5 @@ http_interactions:
         Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849513696],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:04 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:35 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/when_there_are_no_results.yml
+++ b/spec/cassettes/results_page_pagination/when_there_are_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:00 GMT
+      - Tue, 29 Apr 2014 06:34:32 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - ca6e9ff5-b994-4365-b1cc-7fe1baa3ebcd
+      - 68a19b82-db13-4807-ad15-8e6ff366b0c2
       X-Runtime:
-      - '0.070296'
+      - '0.020142'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:00 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:31 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_result.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_result.yml
@@ -25,7 +25,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:01 GMT
+      - Tue, 29 Apr 2014 06:34:34 GMT
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
       Status:
@@ -35,15 +35,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 27a8210c-570e-4a98-8051-2316bab0e5d0
+      - 0fda955c-0b03-4d0b-a838-4159d573858a
       X-Runtime:
-      - '0.080014'
+      - '0.018844'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1749'
       Connection:
       - keep-alive
     body:
@@ -108,5 +108,5 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:01 GMT
+  recorded_at: Tue, 29 Apr 2014 06:34:34 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:54 GMT
+      - Tue, 29 Apr 2014 06:29:33 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 309f8969-d9ac-406c-88be-eb61f898cbf9
+      - 414438dd-0f86-4bd5-b0b2-49cb42581ac8
       X-Runtime:
-      - '0.049621'
+      - '0.018664'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:54 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:32 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:54 GMT
+      - Tue, 29 Apr 2014 06:29:34 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
@@ -95,9 +95,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 069e6b76-409d-4bbd-9ac4-bb683ed107d0
+      - d9122582-3b51-4df0-8efb-08daffc2f078
       X-Runtime:
-      - '0.042888'
+      - '0.022752'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -168,7 +168,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:55 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:33 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=3
@@ -194,7 +194,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:55 GMT
+      - Tue, 29 Apr 2014 06:29:35 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=1>;
         rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2>;
@@ -214,15 +214,15 @@ http_interactions:
       X-Previous-Page:
       - '2'
       X-Request-Id:
-      - a0ce8629-f22c-42f2-b4d8-3f18a642cf69
+      - f210bc79-292f-48cf-a0e8-14868f3aa20a
       X-Runtime:
-      - '0.137943'
+      - '0.014056'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '416'
       Connection:
       - keep-alive
     body:
@@ -231,7 +231,7 @@ http_interactions:
         phone","name":"Location with no phone","created_at":"2014-04-18T12:32:12.179-07:00","slug":"location-with-no-phone","short_desc":"no
         phone","url":"http://ohana-api-test.herokuapp.com/api/locations/20","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849532179],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:55 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:34 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=SanMaceo%20Example%20Agency.&utf8=%E2%9C%93
@@ -257,7 +257,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:56 GMT
+      - Tue, 29 Apr 2014 06:29:36 GMT
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
       Status:
@@ -267,9 +267,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 2ad1e112-1408-432d-928e-a6007fe3c592
+      - 159504b8-d815-4115-82dc-440fa231cab3
       X-Runtime:
-      - '0.078809'
+      - '0.019590'
       X-Total-Count:
       - '1'
       X-Total-Pages:
@@ -340,5 +340,5 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:56 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:35 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_has_results.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:48 GMT
+      - Tue, 29 Apr 2014 06:29:10 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 1ae14cde-ea05-4d8a-90d6-1a797b644d1a
+      - 44ec4d0b-7bc7-4bef-9ddf-47b16625ba70
       X-Runtime:
-      - '0.063484'
+      - '0.020496'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:48 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:09 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:49 GMT
+      - Tue, 29 Apr 2014 06:29:11 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
@@ -95,15 +95,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 34af6b39-0fd3-45c5-9a2c-060a7b9ad78e
+      - 2acfe3aa-23a9-4b7f-aa5c-a6b946062138
       X-Runtime:
-      - '0.060797'
+      - '0.015394'
       X-Total-Count:
       - '2'
       X-Total-Pages:
       - '2'
-      Content-Length:
-      - '1009'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -124,5 +124,5 @@ http_interactions:
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849531266],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:49 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:10 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_no_results.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:34 GMT
+      - Tue, 29 Apr 2014 06:29:15 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 68682720-543b-45f8-85f8-b9e37ec9fde0
+      - 52f2e81c-a6a9-49d5-84f9-697d8c62c764
       X-Runtime:
-      - '0.062762'
+      - '0.019567'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:34 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:14 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=United%20States%20Government&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:34 GMT
+      - Tue, 29 Apr 2014 06:29:16 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -92,9 +92,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 949b9e1b-14df-4ad7-b5ac-a18f1752582b
+      - 83d0b768-10d2-4cb7-81b7-61779cb86e58
       X-Runtime:
-      - '0.047455'
+      - '0.018985'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +107,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:34 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:15 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_custom_value_is_added.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_custom_value_is_added.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:57 GMT
+      - Tue, 29 Apr 2014 06:29:19 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - abfe95a9-85e0-4470-86ba-b64f7ff22f54
+      - aa8a79c1-3ecd-4d34-a40f-8a027f5014da
       X-Runtime:
-      - '0.061154'
+      - '0.017211'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:57 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:18 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:58 GMT
+      - Tue, 29 Apr 2014 06:29:20 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -92,9 +92,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 3c210e56-abf1-4e41-bc83-70306c532809
+      - a4febed5-8125-4c77-acbe-84c98490d5cb
       X-Runtime:
-      - '0.041538'
+      - '0.014674'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +107,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:58 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:19 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:38 GMT
+      - Tue, 29 Apr 2014 06:29:32 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - e255f66e-9f15-42b5-8322-d22e4879bf0b
+      - 2296190e-37b7-4ba9-8ec2-24f486e2c22a
       X-Runtime:
-      - '0.041942'
+      - '0.019523'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:38 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:31 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:28 GMT
+      - Tue, 29 Apr 2014 06:29:21 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - a8e206e4-da96-4472-9f16-6e7665908540
+      - b54ae819-a626-4d36-8552-ebe74f837e40
       X-Runtime:
-      - '0.048642'
+      - '0.027081'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:28 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:20 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_clicking_organization_link_in_results.yml
+++ b/spec/cassettes/results_page_search/when_clicking_organization_link_in_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:50 GMT
+      - Tue, 29 Apr 2014 06:29:05 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - bab143da-bb69-42de-9217-fce3e7c9a35a
+      - 4adf2cc3-a670-495d-ad35-611cb43c0a79
       X-Runtime:
-      - '0.052650'
+      - '0.019867'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:50 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:04 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan%20House&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:51 GMT
+      - Tue, 29 Apr 2014 06:29:06 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=6&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=2&utf8=%E2%9C%93>;
@@ -95,15 +95,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 72393207-6f66-487b-988c-852932c33dd2
+      - 965064a4-5a44-4c70-814e-cbf4b4a6f27d
       X-Runtime:
-      - '0.105774'
+      - '0.022988'
       X-Total-Count:
       - '6'
       X-Total-Pages:
       - '6'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1130'
       Connection:
       - keep-alive
     body:
@@ -128,7 +128,7 @@ http_interactions:
         City Free Medical Clinic","created_at":"2014-04-18T12:32:09.882-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
         Restroom","Wheelchair"],"_score":0.04292514,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:51 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:05 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:51 GMT
+      - Tue, 29 Apr 2014 06:29:06 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
@@ -170,15 +170,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - e9c6da8b-5892-485a-b2a2-47ba8836d55c
+      - d0f07f9b-edf4-4e3c-af32-33e366dd4d11
       X-Runtime:
-      - '0.085782'
+      - '0.018080'
       X-Total-Count:
       - '2'
       X-Total-Pages:
       - '2'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1015'
       Connection:
       - keep-alive
     body:
@@ -199,5 +199,5 @@ http_interactions:
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849531266],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:52 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:05 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_clicking_the_reset_button.yml
+++ b/spec/cassettes/results_page_search/when_clicking_the_reset_button.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:29 GMT
+      - Tue, 29 Apr 2014 06:29:37 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 0ce8a6b0-6305-470b-820f-5014f3b443a5
+      - 29acb9ea-cfc9-497c-84ad-f5e89bac7b0d
       X-Runtime:
-      - '0.037055'
+      - '0.015412'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:29 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:36 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:30 GMT
+      - Tue, 29 Apr 2014 06:29:38 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
@@ -95,9 +95,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - d9d98a4e-a83a-4333-984d-1d082adbf5f3
+      - 82ce6f4c-ff69-4f4c-aef6-2940dcd0a8dd
       X-Runtime:
-      - '0.029891'
+      - '0.017672'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -168,5 +168,5 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:30 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:37 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:42 GMT
+      - Tue, 29 Apr 2014 06:29:12 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - c596f95c-23fb-4cc3-b1a8-04b6efdaa1df
+      - 2c91613a-57df-4105-bc21-041472c92ec0
       X-Runtime:
-      - '0.027565'
+      - '0.025916'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:42 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:11 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:43 GMT
+      - Tue, 29 Apr 2014 06:29:13 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
@@ -95,15 +95,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 7ad618b0-e454-4238-9074-485bd96a3cce
+      - a0546cdd-41f8-42e0-95dc-604dd51561ba
       X-Runtime:
-      - '0.129800'
+      - '0.014939'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1753'
       Connection:
       - keep-alive
     body:
@@ -168,7 +168,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:44 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:12 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=fairfax,%20va&utf8=%E2%9C%93
@@ -194,7 +194,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:44 GMT
+      - Tue, 29 Apr 2014 06:29:13 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -207,9 +207,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 638a1462-e122-43b8-8dbb-e323ea83b493
+      - f3a88368-2c22-4ebf-8c44-c5376a955a38
       X-Runtime:
-      - '0.056629'
+      - '0.018551'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -222,5 +222,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:44 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:12 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_has_results.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:45 GMT
+      - Tue, 29 Apr 2014 06:29:29 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - bb8264a9-87a9-48ff-934c-575aaa792335
+      - 47a18b92-c227-4d9d-8c24-afc691554b4f
       X-Runtime:
-      - '0.040869'
+      - '0.017275'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:45 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:28 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San%20Mateo,%20CA&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:46 GMT
+      - Tue, 29 Apr 2014 06:29:30 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=6&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=2&utf8=%E2%9C%93>;
@@ -95,9 +95,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - af428c94-6178-46d8-ac63-75ed4f133a99
+      - 9ff9fb97-0ad4-4eb0-ab40-f2006d885322
       X-Runtime:
-      - '0.071140'
+      - '0.025491'
       X-Total-Count:
       - '6'
       X-Total-Pages:
@@ -139,5 +139,5 @@ http_interactions:
         Family Service Agency of San Mateo County, Senior Employment Services.","name":"Second
         Career Employment Program","created_at":"2014-04-18T12:31:54.689-07:00","slug":"second-career-employment-program","longitude":-122.3263232,"latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.07871992834851854],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:47 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:29 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_no_results.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:59 GMT
+      - Tue, 29 Apr 2014 06:29:03 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - f268b686-4bb5-4151-8074-3a2dbafae7e4
+      - 6bababe6-5316-475b-b47d-21b8cb7681f9
       X-Runtime:
-      - '0.043375'
+      - '0.017840'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:59 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:02 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=San%20Mateo,%20CA&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:00 GMT
+      - Tue, 29 Apr 2014 06:29:04 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -92,9 +92,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - ee213307-91eb-49a3-a1c8-7f3ed0b06290
+      - d713a5ac-b40d-4f53-a0f5-3e6ef6e81660
       X-Runtime:
-      - '0.055934'
+      - '0.017743'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +107,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:00 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:03 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_custom_value_is_added.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_custom_value_is_added.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:31 GMT
+      - Tue, 29 Apr 2014 06:29:08 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - b88560bd-befa-4c32-a01d-65a803406be8
+      - 275c6d75-535b-4957-b080-7693b2055e7e
       X-Runtime:
-      - '0.121032'
+      - '0.016927'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:31 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:07 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:32 GMT
+      - Tue, 29 Apr 2014 06:29:09 GMT
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
       Status:
@@ -87,9 +87,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 7d2fc1f5-52df-4552-b5ae-9d09399ae3ca
+      - d923e86a-6146-4017-9816-5ade1a12840e
       X-Runtime:
-      - '0.157876'
+      - '0.098156'
       Content-Length:
       - '68'
       Connection:
@@ -98,7 +98,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:32 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:08 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
@@ -124,7 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:32 GMT
+      - Tue, 29 Apr 2014 06:29:09 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -137,9 +137,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 0af0c4bc-9942-4344-ba48-77d8708a9620
+      - 73a2627a-b423-45dc-a68a-84d803fc43d0
       X-Runtime:
-      - '0.064302'
+      - '0.025430'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -152,5 +152,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:32 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:08 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:53 GMT
+      - Tue, 29 Apr 2014 06:29:17 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 93b5edc4-b913-4fa5-a1e0-5fa3a1719036
+      - b3f556e1-76d4-4aaa-badc-244b19a70eff
       X-Runtime:
-      - '0.067094'
+      - '0.021477'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:53 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:16 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:39 GMT
+      - Tue, 29 Apr 2014 06:29:22 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - ca1cacbf-1d88-4170-9f9c-c2c870c8489a
+      - 11fb0a88-8b83-42e2-aa02-61d6ef1b5164
       X-Runtime:
-      - '0.082174'
+      - '0.015442'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:39 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:21 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:36 GMT
+      - Tue, 29 Apr 2014 06:29:23 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - dcaa79be-b2b9-436b-be82-e5b53eb8cbf2
+      - d188121a-f8c4-4ddc-b539-ecc341b8c31d
       X-Runtime:
-      - '0.060304'
+      - '0.017329'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:36 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:23 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:36 GMT
+      - Tue, 29 Apr 2014 06:29:24 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
@@ -95,9 +95,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 95d5c249-c7a6-480e-95d2-613bd93659e0
+      - 955762af-b28b-4373-82b0-df2103f70211
       X-Runtime:
-      - '0.050664'
+      - '0.033043'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -168,7 +168,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:36 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:23 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
@@ -194,7 +194,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:37 GMT
+      - Tue, 29 Apr 2014 06:29:25 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
@@ -210,15 +210,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - f75b82bf-e287-44d8-aa85-a2ddf27e8626
+      - 46574d28-486a-4e5a-b277-3800eb043f94
       X-Runtime:
-      - '0.041279'
+      - '0.018341'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1753'
       Connection:
       - keep-alive
     body:
@@ -283,5 +283,5 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:37 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:24 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:01 GMT
+      - Tue, 29 Apr 2014 06:29:27 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - a5063aad-84f3-4da4-846e-66542edcb257
+      - 827f6a8e-6030-4937-a609-3a01d024a2ee
       X-Runtime:
-      - '0.075686'
+      - '0.014522'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:01 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:27 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,11 +25,11 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:40 GMT
+      - Tue, 29 Apr 2014 06:29:39 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -38,9 +38,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 05d47509-1244-4d60-b2b9-5eb4af1d0001
+      - 3317d5e8-cf73-4fd5-b87f-85380a91084a
       X-Runtime:
-      - '0.045910'
+      - '0.015836'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,7 +53,7 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:40 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:38 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=smc&utf8=%E2%9C%93
@@ -79,7 +79,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:47:41 GMT
+      - Tue, 29 Apr 2014 06:29:40 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -92,9 +92,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - de009040-4c27-43e2-84ce-61f5219db32c
+      - 447be742-e8ec-4a90-8a4f-7f4deb8324fa
       X-Runtime:
-      - '0.046511'
+      - '0.021008'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +107,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:47:41 GMT
+  recorded_at: Tue, 29 Apr 2014 06:29:39 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:12 GMT
+      - Tue, 29 Apr 2014 06:28:41 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,15 +41,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 569a26f8-b67a-4bf5-ba63-9d11589498cf
+      - 7f1965ab-6bb4-4f3d-957a-e7bcdc0f9807
       X-Runtime:
-      - '0.034893'
+      - '0.035885'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1753'
       Connection:
       - keep-alive
     body:
@@ -114,7 +114,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:12 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:40 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=sdaff&location=94403&utf8=%E2%9C%93
@@ -140,7 +140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:12 GMT
+      - Tue, 29 Apr 2014 06:28:42 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -153,9 +153,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 31f0dafb-f67b-41c7-9220-e0a221d6f4b8
+      - c384f548-89a4-457c-9d5c-95fac70989d0
       X-Runtime:
-      - '0.061740'
+      - '0.044034'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -168,5 +168,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:12 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:42 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:09 GMT
+      - Tue, 29 Apr 2014 06:28:44 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 68dc11d5-f965-40d7-a859-d2659d82e088
+      - 161c5aa0-961e-4d99-bdc2-b9169cdbd949
       X-Runtime:
-      - '0.041171'
+      - '0.030434'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,7 +114,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:09 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:43 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=clinic&location=94403&utf8=%E2%9C%93
@@ -140,7 +140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:10 GMT
+      - Tue, 29 Apr 2014 06:28:44 GMT
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
       Status:
@@ -150,15 +150,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - afbd9cfb-3ff1-49b9-aa6c-63d203178d33
+      - 09ac5795-2c99-4879-bb18-09be7bdb8006
       X-Runtime:
-      - '0.050290'
+      - '0.050605'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1020'
       Connection:
       - keep-alive
     body:
@@ -179,5 +179,5 @@ http_interactions:
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.6741946265175476],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:10 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:43 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:10 GMT
+      - Tue, 29 Apr 2014 06:28:48 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,15 +41,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 12fed705-8484-498f-a7e1-225f8dc9f30e
+      - 6d7a78a2-0e84-4654-af7e-52aac5620b6a
       X-Runtime:
-      - '0.083893'
+      - '0.019044'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1747'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -114,7 +114,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:10 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:47 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
@@ -140,7 +140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:11 GMT
+      - Tue, 29 Apr 2014 06:28:48 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -153,9 +153,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 824ecf23-5c86-4900-8c4b-7926957827f1
+      - bee6555e-c4fe-4781-aa18-1554f0744e34
       X-Runtime:
-      - '0.057370'
+      - '0.034121'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -168,5 +168,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:11 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:47 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:17 GMT
+      - Tue, 29 Apr 2014 06:28:47 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 7dc6dd39-832c-4934-9017-f4b0983eec98
+      - 562b883c-bba2-4c96-9a3e-884c2df5c537
       X-Runtime:
-      - '0.068660'
+      - '0.020170'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,7 +114,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:17 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:46 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
@@ -140,7 +140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:17 GMT
+      - Tue, 29 Apr 2014 06:28:47 GMT
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
       Status:
@@ -150,9 +150,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 7ea61600-229a-48cf-9f3b-7c29626baa85
+      - b2b82409-f1e0-4beb-a7ed-d028a524408a
       X-Runtime:
-      - '0.041652'
+      - '0.023558'
       X-Total-Count:
       - '1'
       X-Total-Pages:
@@ -223,5 +223,5 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:17 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:46 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_location_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_location_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:13 GMT
+      - Tue, 29 Apr 2014 06:28:45 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 5436e120-8456-40a9-af0c-6a3b58d7c394
+      - 4ef841a1-392e-415d-a672-aff9e8e3373c
       X-Runtime:
-      - '0.051870'
+      - '0.026328'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,7 +114,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:13 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:44 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=asdfg&utf8=%E2%9C%93
@@ -140,7 +140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:14 GMT
+      - Tue, 29 Apr 2014 06:28:46 GMT
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
       Status:
@@ -148,9 +148,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - cc2b005c-2e81-4951-af5d-7bc4e69e78a0
+      - aa147e4e-df1a-4ab6-b0ea-401114f7d572
       X-Runtime:
-      - '0.054214'
+      - '0.018605'
       Content-Length:
       - '68'
       Connection:
@@ -159,7 +159,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:14 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:45 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
@@ -185,7 +185,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:14 GMT
+      - Tue, 29 Apr 2014 06:28:46 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
@@ -198,9 +198,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 643f875d-70aa-4412-b3a7-bf784ac8ffec
+      - 6d5df244-ab9b-4546-a54e-315ef19e32e1
       X-Runtime:
-      - '0.024123'
+      - '0.014683'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -213,5 +213,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:14 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:45 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_location_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_location_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -25,10 +25,10 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:15 GMT
+      - Tue, 29 Apr 2014 06:28:49 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
       - nginx/1.4.7 + Phusion Passenger 4.0.40
@@ -41,9 +41,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - f2a9c583-caa2-430a-956e-0bfcc516ff2a
+      - 195f0256-cb53-467d-885c-e34c7df178a5
       X-Runtime:
-      - '0.033763'
+      - '0.043455'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -114,7 +114,7 @@ http_interactions:
         Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
         Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:15 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:48 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&utf8=%E2%9C%93
@@ -140,7 +140,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 28 Apr 2014 18:48:16 GMT
+      - Tue, 29 Apr 2014 06:28:50 GMT
       Link:
       - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=6&utf8=%E2%9C%93>;
         rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=2&utf8=%E2%9C%93>;
@@ -156,15 +156,15 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger 4.0.40
       X-Request-Id:
-      - 727d750f-dcea-4e6e-9b7e-4a002a2deebe
+      - 6ee7b558-7485-4e42-a258-7d6a6447b30e
       X-Runtime:
-      - '0.049486'
+      - '0.018741'
       X-Total-Count:
       - '6'
       X-Total-Pages:
       - '6'
-      Content-Length:
-      - '1014'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -185,5 +185,5 @@ http_interactions:
         dental care to those in need. Offers basic medical care for adults.","name":"San
         Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.6741946265175476],"highlight":null,"_explanation":null}]'
     http_version: 
-  recorded_at: Mon, 28 Apr 2014 18:48:16 GMT
+  recorded_at: Tue, 29 Apr 2014 06:28:49 GMT
 recorded_with: VCR 2.9.0


### PR DESCRIPTION
- Updates style of geolocation “Services near me” button to use small
  button style. Also moves the geolocation button on the homepage from
  the lower-right corner to under the search button.
- Adjusts the height of the language-box area to reduce the overall
  height slightly.
- Adjusts responsive styles to accommodate move of geolocate button.
- Adjusts location manager to use main search form, instead of location
  form (also removes location form because it’s no longer needed as the
  geolocate button is now located in the main form).
- Updates cassettes to include location in URL parameters.
