### PR TITLE
Fixes #399 - removes token from travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,3 @@ notifications:
     on_success: never
     on_failure: always
   webhooks: http://cfa-project-monitor.herokuapp.com/projects/67f80d53-afb0-4344-bd40-2644f55a4462/status
-env:
-  matrix:
-    - secure: ZhrMOK9JCzqqiI3mHBNh/g/bUWEZe+SXn91eZuU0zdFKrUlCRwglhABiIf+9a1Ysk1aB0g4LO4tNTV0ku7cdQUHeNabueho88qUKyDj70QB05xHEgtcjelgpD2F9InVi8D47S9UG6LBf9gJAXGN7UTw2CH+sm9q5SLbrKb9fszo=

--- a/spec/cassettes/Search_summary/when_visiting_search_results_page_that_does_not_have_results.yml
+++ b/spec/cassettes/Search_summary/when_visiting_search_results_page_that_does_not_have_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfdsggfdg
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfdsggfdg
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:53 GMT
+      - Fri, 16 May 2014 07:49:48 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfdsggfdg&page=0>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfdsggfdg&page=0&per_page=1>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - b15eb411-49a0-4242-bef2-5763e6b759cf
+      - 60e0bde4-4f36-4343-ade2-f543d09f493f
       X-Runtime:
-      - '0.023296'
+      - '0.019029'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:53 GMT
+  recorded_at: Fri, 16 May 2014 07:49:48 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/Search_summary/when_visiting_search_results_page_that_has_results.yml
+++ b/spec/cassettes/Search_summary/when_visiting_search_results_page_that_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:53 GMT
+      - Fri, 16 May 2014 07:49:48 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - b9e23961-fdb6-43e1-9d66-10784011289d
+      - 8e212656-3c45-422e-93c0-a96422e13b11
       X-Runtime:
-      - '0.025743'
+      - '0.056731'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1629'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -59,13 +58,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -78,35 +78,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:53 GMT
+  recorded_at: Fri, 16 May 2014 07:49:48 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/Site_Pages/when_visiting_results_page_directly.yml
+++ b/spec/cassettes/Site_Pages/when_visiting_results_page_directly.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,19 +23,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:27 GMT
+      - Fri, 16 May 2014 07:48:16 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 8679be60-5c61-4554-8b35-a34d82353996
+      - 06604b63-c50e-4dee-8742-d110fc8aa114
       X-Runtime:
-      - '0.046503'
+      - '0.055566'
       X-Total-Count:
       - '1'
       X-Total-Pages:
@@ -48,8 +46,9 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -59,13 +58,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -78,35 +78,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:27 GMT
+  recorded_at: Fri, 16 May 2014 07:48:16 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/StatusController/GET_/_well-known/status/when_everything_is_fine/returns_success.yml
+++ b/spec/cassettes/StatusController/GET_/_well-known/status/when_everything_is_fine/returns_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,19 +23,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:26 GMT
+      - Fri, 16 May 2014 07:47:52 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - eb1af63a-1c44-4920-b85c-c8b9a3bb4ecb
+      - 9948882c-eefb-49ae-99bb-b5a91d94e395
       X-Runtime:
-      - '0.060131'
+      - '0.033618'
       Content-Length:
-      - '867'
+      - '888'
       Connection:
       - keep-alive
     body:
@@ -52,17 +50,17 @@ http_interactions:
         Mateo Free Medical Clinic","phones":[{"id":19,"number":"650 578-0400"}],"short_desc":"Provides
         free medical and dental care to those in need. Offers basic medical care for
         adults.","slug":"san-mateo-free-medical-clinic","transportation":"SAMTRANS
-        stops within 1 block.","updated_at":"2014-04-18T12:32:11.939-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/19","services":[{"id":19,"eligibility":"Low-income
+        stops within 1 block.","updated_at":"2014-05-09T21:37:14.734-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/19","services":[{"id":19,"eligibility":"Low-income
         person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
         SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
         screening appointment (650-347-3648).","service_areas":["Belmont","Burlingame","Foster
         City","Millbrae","San Carlos","San Mateo"],"wait":"Varies.","updated_at":"2014-04-18T12:32:11.921-07:00"}],"organization":{"id":5,"name":"Samaritan
         House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:26 GMT
+  recorded_at: Fri, 16 May 2014 07:47:52 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -71,8 +69,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -85,31 +81,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:26 GMT
+      - Fri, 16 May 2014 07:47:52 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 96e5e0e0-ffad-4773-a533-8a0824586959
+      - 69518577-c7ba-4243-9d26-b540dfeac862
       X-Runtime:
-      - '0.023784'
+      - '0.042528'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Content-Length:
-      - '1749'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -119,13 +116,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -138,35 +136,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:26 GMT
+  recorded_at: Fri, 16 May 2014 07:47:52 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_a_Google_Maps_directions_link.yml
+++ b/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_a_Google_Maps_directions_link.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,31 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:35 GMT
+      - Fri, 16 May 2014 07:48:07 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 6bbc1e72-e705-429d-9c5e-8c302ea72d3f
+      - c3130e8b-8b83-471c-bcde-2704e9ada057
       X-Runtime:
-      - '0.059381'
+      - '0.037718'
       Content-Length:
-      - '317'
+      - '301'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":20,"description":"no phone","kind":"Test","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-18T12:32:12.272-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"organization":{"id":6,"name":"Location
+      string: '{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
         with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:35 GMT
+  recorded_at: Fri, 16 May 2014 07:48:07 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone
     body:
       encoding: US-ASCII
       string: ''
@@ -58,8 +56,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -72,26 +68,26 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:35 GMT
+      - Fri, 16 May 2014 07:48:07 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 9f316239-0835-430b-980f-b104305bcf31
+      - afa4b429-4be8-475d-bc8a-6fc270fa8299
       X-Runtime:
-      - '0.063716'
+      - '0.031743'
       Content-Length:
-      - '317'
+      - '307'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":20,"description":"no phone","kind":"Test","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-18T12:32:12.272-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"organization":{"id":6,"name":"Location
+      string: '{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
         with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:35 GMT
+  recorded_at: Fri, 16 May 2014 07:48:08 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_the_physical_address_header.yml
+++ b/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_the_physical_address_header.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,31 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:34 GMT
+      - Fri, 16 May 2014 07:48:06 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 1b6d418b-ae02-42c3-9bbb-8ab83585b14b
+      - 74e6fc58-8dbf-4254-b1b6-ba02d0f87154
       X-Runtime:
-      - '0.055833'
+      - '0.059023'
       Content-Length:
-      - '317'
+      - '301'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":20,"description":"no phone","kind":"Test","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-18T12:32:12.272-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"organization":{"id":6,"name":"Location
+      string: '{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
         with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:34 GMT
+  recorded_at: Fri, 16 May 2014 07:48:06 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone
     body:
       encoding: US-ASCII
       string: ''
@@ -58,8 +56,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -72,26 +68,26 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:34 GMT
+      - Fri, 16 May 2014 07:48:07 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - c9a39216-5bd5-458d-b94e-d1fb72c25780
+      - 468719e7-af6d-424c-9927-1f83e2958311
       X-Runtime:
-      - '0.052039'
+      - '0.029713'
       Content-Length:
-      - '311'
+      - '301'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":20,"description":"no phone","kind":"Test","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-18T12:32:12.272-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"organization":{"id":6,"name":"Location
+      string: '{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
         with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:34 GMT
+  recorded_at: Fri, 16 May 2014 07:48:07 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/all_results.yml
+++ b/spec/cassettes/all_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:27 GMT
+      - Fri, 16 May 2014 07:48:09 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,80 +37,60 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 13e22723-d0a4-4b26-afa9-b97b73588f87
+      - e0a432ff-0454-455a-932f-ad060ac14c3a
       X-Runtime:
-      - '0.021428'
+      - '0.045005'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1813'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:28 GMT
+  recorded_at: Fri, 16 May 2014 07:48:09 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/detail_view_map/location_does_not_have_coordinates/does_not_display_a_map.yml
+++ b/spec/cassettes/detail_view_map/location_does_not_have_coordinates/does_not_display_a_map.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,31 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:27 GMT
+      - Fri, 16 May 2014 07:48:06 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4dca6656-9ab5-46a6-99f4-0fa5211c9b1c
+      - e84be7bc-de4f-4e7e-a000-7fa18d697e7c
       X-Runtime:
-      - '0.097892'
+      - '0.049942'
       Content-Length:
-      - '311'
+      - '307'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":20,"description":"no phone","kind":"Test","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-18T12:32:12.272-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"organization":{"id":6,"name":"Location
+      string: '{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
         with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:27 GMT
+  recorded_at: Fri, 16 May 2014 07:48:06 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/location-with-no-phone
     body:
       encoding: US-ASCII
       string: ''
@@ -58,8 +56,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -72,26 +68,26 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:27 GMT
+      - Fri, 16 May 2014 07:48:06 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 925087fe-9db9-4599-9925-834763207433
+      - 4b122b45-e689-4b61-b1f9-8bde3bdc13af
       X-Runtime:
-      - '0.118220'
+      - '0.030308'
       Content-Length:
-      - '311'
+      - '307'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"id":20,"description":"no phone","kind":"Test","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
-        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-04-18T12:32:12.272-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"organization":{"id":6,"name":"Location
+      string: '{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
         with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:27 GMT
+  recorded_at: Fri, 16 May 2014 07:48:06 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/detail_view_map/location_has_coordinates/displays_a_map.yml
+++ b/spec/cassettes/detail_view_map/location_has_coordinates/displays_a_map.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,19 +23,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:25 GMT
+      - Fri, 16 May 2014 07:48:05 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - c3e96e07-08fc-4223-8d2e-d49c90733870
+      - 575b8907-9a53-41e2-a562-4ed9f1c382a1
       X-Runtime:
-      - '0.234292'
+      - '0.051287'
       Content-Length:
-      - '1643'
+      - '1631'
       Connection:
       - keep-alive
     body:
@@ -61,25 +59,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -97,13 +77,31 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
         Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:25 GMT
+  recorded_at: Fri, 16 May 2014 07:48:05 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -112,8 +110,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -126,17 +122,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:26 GMT
+      - Fri, 16 May 2014 07:48:06 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - aee372f1-4cb9-4ddf-87ef-87af587913cc
+      - b59478b1-f1b2-44ed-8321-fd3a2dc81e7e
       X-Runtime:
-      - '0.407629'
+      - '0.067422'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -162,25 +158,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -198,8 +176,26 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
         Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:26 GMT
+  recorded_at: Fri, 16 May 2014 07:48:06 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/dynamic/location_details/phone_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/phone_dynamic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -102,7 +100,7 @@ http_interactions:
   recorded_at: Thu, 17 Apr 2014 03:38:57 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -111,8 +109,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:

--- a/spec/cassettes/dynamic/location_details/superscript_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/superscript_dynamic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -102,7 +100,7 @@ http_interactions:
   recorded_at: Thu, 17 Apr 2014 03:46:23 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -111,8 +109,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:

--- a/spec/cassettes/dynamic/location_details/url_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/url_dynamic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -103,7 +101,7 @@ http_interactions:
   recorded_at: Thu, 17 Apr 2014 03:49:05 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -112,8 +110,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:

--- a/spec/cassettes/homepage_search/when_clicking_a_category.yml
+++ b/spec/cassettes/homepage_search/when_clicking_a_category.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20Insurance
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Health%20Insurance
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:09 GMT
+      - Fri, 16 May 2014 07:49:58 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+Insurance&page=7>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+Insurance&page=2>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Health+Insurance&page=2&per_page=1>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Health+Insurance&page=2&per_page=1>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,63 +37,57 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 63bf3ce8-3760-4530-94d0-2019f746f7ba
+      - 47cf3838-3eca-40d4-9f7d-717c790f3cce
       X-Runtime:
-      - '0.022833'
+      - '0.044195'
       X-Total-Count:
-      - '7'
+      - '2'
       X-Total-Pages:
-      - '7'
+      - '2'
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":1,"audience":"Older adults age 55 or over, ethnic
-        minorities and low-income persons","eligibility":"Age 55 or over for most
-        programs, age 60 or over for lunch program","fees":"$2.50 suggested donation
-        for lunch for age 60 or over, donations for other services appreciated. Cash
-        and checks accepted.","how_to_apply":"Walk in or apply by phone.","wait":"No
-        wait.","funding_sources":["City","County","Donations","Fees","Fundraising"],"service_areas":["Redwood
-        City"],"keywords":["ADULT PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered
-        Mea","COMMUNITY SERVICES","Group Support","Information and Referral","EDUCATION
-        SERVICES","English Language","RECREATION/LEISURE SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown
-        Bag Food Programs","Congregate Meals/Nutrition Sites","Senior Centers","Older
-        Adults"],"updated_at":"2014-04-18T12:31:54.284-07:00"}],"mail_address":{"id":1,"location_id":1,"attention":"Fair
-        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
-        stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
-        780-7525"}],"contacts":[{"id":1,"location_id":1,"name":"Susan Houston","title":"Director
-        of Older Adult Services"},{"id":2,"location_id":1,"name":"Christina Gonzalez","title":"Center
-        Director"}],"id":"1","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:54.310-07:00","faxes":[{"id":1,"location_id":1,"number":"650
-        701-0856"}],"address":{"id":1,"location_id":1,"street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"description":"A walk-in center for older
-        adults that provides social services, wellness, recreational, educational
-        and creative activities including arts and crafts, computer classes and gardening
-        classes. Coffee and healthy breakfasts are available daily. A hot lunch is
-        served Tuesday-Friday for persons age 60 or over and spouse.        Provides
-        case management (including in-home assessments) and bilingual information
-        and referral about community services to persons age 60 or over on questions
-        of housing, employment, household help, recreation and social activities,
-        home delivered meals, health and counseling services and services to shut-ins.
-        Health insurance and legal counseling is available by appointment. Lectures
-        on a variety of health and fitness topics are held monthly in both English
-        and Spanish.  Provides a variety of physical fitness opportunities, including
-        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
-        toward older adults. Also provides free monthly blood pressure screenings,
-        quarterly blood glucose monitoring and health screenings by a visiting nurse.
-        Offers a Brown Bag Program in which low-income seniors can receive a bag of
-        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
-        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
-        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
-        Agency of San Mateo County, Fair Oaks Intergenerational Center.","name":"Fair
-        Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.0064387713,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+      string: '[{"id":6,"accessibility":["Disabled Parking","Wheelchair"],"address":{"id":6,"street":"800
+        Middle Avenue","city":"Menlo Park","state":"CA","zip":"94025-9881"},"contacts":[{"id":7,"name":"Peter
+        Olson","title":"Little House Director"},{"id":8,"name":"Bart Charlow","title":"Executive
+        Director, Peninsula Volunteers"}],"coordinates":[-122.1805905,37.4480204],"description":"A
+        multipurpose center offering a wide variety of recreational, education and
+        cultural activities. Lifelong learning courses cover topics such as music,
+        art, languages, etc., are hosted at this location. Little House offers a large
+        variety of classes including arts and crafts, jewelry, languages, current
+        events, lapidary, woodwork, painting, and fitness courses (yoga, strength
+        straining, tai chi). There are monthly art and cultural lectures, movie showings,
+        and a computer center. Recreation activities include mah jong, pinochle, ballroom
+        dancing, bridge, trips and tours. Partners with the Sequoia Adult Education
+        Program. The Alzheimer''s Cafe, open the third Tuesday of every month from
+        2:00 - 4:00 pm, is a place that brings together people liviing with dementia,
+        their families, and their caregivers. Free and no registration is needed.
+        The Little House Community Service Desk offers information and referrals regarding
+        social service issues, such as housing, food, transportation, health insurance
+        counseling, and estate planning. Massage, podiatry, and acupuncture are available
+        by appointment. Lunch is served Monday-Friday, 11:30 am-1:00 pm. Prices vary
+        according to selection.","emails":["polson@peninsulavolunteers.org"],"faxes":[{"id":6,"number":"650
+        326-9547"}],"hours":"Monday-Thursday, 8 am-9 pm; Friday, 8-5","languages":["Filipino
+        (Tagalog)","Spanish"],"mail_address":{"id":6,"attention":"Little House","street":"800
+        Middle Avenue","city":"Menlo Park","state":"CA","zip":"94025-9881"},"name":"Little
+        House","phones":[{"id":6,"number":"650 326-2025"}],"short_desc":"A multipurpose
+        senior citizens'' center.","slug":"little-house","transportation":"SAMTRANS
+        stops within 3 blocks, RediWheels and Menlo Park Shuttle stop at door.","updated_at":"2014-05-09T21:31:31.747-07:00","urls":["http://www.penvol.org/littlehouse"],"url":"http://ohana-api-test.herokuapp.com/api/locations/6","services":[{"id":6,"audience":"Any
+        age","eligibility":"None","fees":"$55 per year membership dues. Classes have
+        fees. Discounts are available for members. Cash, checks and credit cards accepted.","funding_sources":["Fees","Fundraising","Grants","Membership
+        dues"],"keywords":["ADULT PROTECTION AND CARE SERVICES","In-Home Supportive","Meal
+        Sites/Home-delivered Meals","COMMUNITY SERVICES","Group Support","Information
+        and Referral","EDUCATION SERVICES","Adult","HEALTH SERVICES","Education/Information","Family
+        Support","Individual/Group Counseling","Screening/Immunization","RECREATION/LEISURE
+        SERVICES","Sports/Games/Exercise","Community Adult Schools","Senior Centers","Older
+        Adults"],"how_to_apply":"Walk in or apply by phone for membership application.","service_areas":["San
+        Mateo County","Santa Clara County"],"wait":"No wait.","updated_at":"2014-04-18T12:31:59.022-07:00"}],"organization":{"id":2,"name":"Peninsula
+        Volunteers","slug":"peninsula-volunteers","url":"http://ohana-api-test.herokuapp.com/api/organizations/2","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/2/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:09 GMT
+  recorded_at: Fri, 16 May 2014 07:49:58 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_food_stamps_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_food_stamps_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food%20stamps&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=food%20stamps&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,59 +23,33 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:19 GMT
+      - Fri, 16 May 2014 07:49:57 GMT
+      Etag:
+      - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&location=&page=5&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=food+stamps&location=&page=2&service_area=&utf8=%E2%9C%93>;
-        rel="next"
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=food+stamps&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
-      X-Current-Page:
-      - '1'
-      X-Next-Page:
-      - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 65e3d030-e777-47e0-94c2-ad1efd17e3b8
+      - 587c5e96-211f-4243-9b49-2aa1bf91f9c8
       X-Runtime:
-      - '0.024810'
+      - '0.020799'
       X-Total-Count:
-      - '5'
+      - '0'
       X-Total-Pages:
-      - '5'
+      - '0'
       Content-Length:
-      - '1338'
+      - '2'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":17,"eligibility":"Low-income families","fees":"None.","how_to_apply":"Call
-        for information.","funding_sources":["Donations"],"service_areas":["Brisbane","Colma","Daly
-        City","Millbrae","Pacifica","San Bruno","South San Francisco"],"keywords":["COMMODITY
-        SERVICES","Clothing/Personal Items","COMMUNITY SERVICES","Information and
-        Referral","EMERGENCY SERVICES","Food Boxes/Food Vouchers","FINANCIAL ASSISTANCE
-        SERVICES","Utilities","Emergency Food","Food Pantries","Furniture","Clothing","Utility
-        Assistance","School Supplies","Case/Care Management","Holiday Programs","Pastoral
-        Counseling","Low Income"],"updated_at":"2014-04-18T12:32:09.357-07:00"}],"mail_address":{"id":17,"location_id":17,"attention":"Salvation
-        Army","street":"409 South Spruce Avenue","city":"South San Francisco","state":"CA","zip":"94080"},"hours":"Monday-Thursday,
-        9-4:30","urls":["http://www.tsagoldenstate.org"],"transportation":"SAMTRANS
-        stops within 1 block, BART stops within 3 blocks.","short_desc":"Provides
-        emergency food and clothing and furniture vouchers to low-income families
-        in times of crisis.","url":"http://ohana-api-test.herokuapp.com/api/locations/17","phones":[{"id":17,"location_id":17,"number":"650
-        266-4591"}],"contacts":[{"id":25,"location_id":17,"name":"Kenneth Gibson","title":"Major"}],"id":"17","organization":{"id":4,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-18T12:32:05.934-07:00","updated_at":"2014-04-18T12:32:09.483-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-18T12:32:09.369-07:00","faxes":[{"id":16,"location_id":17,"number":"650
-        266-2594"},{"id":17,"location_id":17,"number":"650 266-4594"}],"address":{"id":17,"location_id":17,"street":"409
-        South Spruce Avenue","city":"South San Francisco","state":"CA","zip":"94080"},"description":"Provides
-        emergency food, clothing and furniture vouchers to low-income families in
-        times of crisis.   Administers Project REACH (Relief for Energy Assistance
-        through Community Help) funds to prevent energy shut-off through a one-time
-        payment. Offers a Saturday morning Homeless Feeding Program at 10:30, as well
-        as Sunday services and spiritual counseling. Provides Christmas toys and Back-to-School
-        clothes and supplies. Offers case management, advocacy and referrals to other
-        agencies.","name":"South San Francisco Citadel Corps","created_at":"2014-04-18T12:32:08.969-07:00","longitude":-122.4224905,"slug":"south-san-francisco-citadel-corps","latitude":37.6445898,"coordinates":[-122.4224905,37.6445898],"accessibility":["Wheelchair"],"_score":0.0038341554,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+      string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:20 GMT
+  recorded_at: Fri, 16 May 2014 07:49:57 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_health_care_reform_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_health_care_reform_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health%20care%20reform&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Health%20care%20reform&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,54 +23,33 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:14 GMT
+      - Fri, 16 May 2014 07:49:56 GMT
+      Etag:
+      - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&location=&page=10&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Health+care+reform&location=&page=2&service_area=&utf8=%E2%9C%93>;
-        rel="next"
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Health+care+reform&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
-      X-Current-Page:
-      - '1'
-      X-Next-Page:
-      - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 74a9f59f-fe1f-4366-90c2-393e1ce9d935
+      - 442d7f0a-d556-4023-bf67-2b45f4974ccb
       X-Runtime:
-      - '0.050446'
+      - '0.032404'
       X-Total-Count:
-      - '10'
+      - '0'
       X-Total-Pages:
-      - '10'
+      - '0'
       Content-Length:
-      - '1132'
+      - '2'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":18,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment.
-        Medical visits are by appointment only.","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Atherton","East
-        Palo Alto","Menlo Park","Redwood City","San Carlos"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:10.649-07:00"}],"mail_address":{"id":18,"location_id":18,"attention":"Redwood
-        City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
-        9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/18","phones":[{"id":18,"location_id":18,"number":"650
-        839-1447"}],"contacts":[{"id":26,"location_id":18,"name":"Sharon Petersen","title":"Administrator"}],"id":"18","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:10.666-07:00","faxes":[{"id":18,"location_id":18,"number":"650
-        839-1457"}],"address":{"id":18,"location_id":18,"street":"114 Fifth Avenue","city":"Redwood
-        City","state":"CA","zip":"94063"},"description":"Provides free medical care
-        to those in need. Offers basic medical exams for adults and tuberculosis screening.
-        Assists the individual to access other services in the community. By appointment
-        only, Project Smile provides a free dental exam, dental cleaning and oral
-        hygiene instruction for children, age 3-12, of Samaritan House clients.","name":"Redwood
-        City Free Medical Clinic","created_at":"2014-04-18T12:32:09.882-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
-        Restroom","Wheelchair"],"_score":0.0060132295,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+      string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:15 GMT
+  recorded_at: Fri, 16 May 2014 07:49:56 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_sfmnp_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_sfmnp_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=SFMNP&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:06 GMT
+      - Fri, 16 May 2014 07:49:55 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=SFMNP&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=SFMNP&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 3fff52f4-13ee-4c58-bc66-6bc038c52606
+      - 95eec9d3-0a5f-4cba-a543-45e60e3d33ae
       X-Runtime:
-      - '0.027911'
+      - '0.026126'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:06 GMT
+  recorded_at: Fri, 16 May 2014 07:49:55 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/when_searching_for_wic_.yml
+++ b/spec/cassettes/homepage_search/when_searching_for_wic_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=wic&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:08 GMT
+      - Fri, 16 May 2014 07:49:54 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=wic&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=wic&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4b976f99-e200-40c3-983e-4931db5f5d6d
+      - 3e79d546-4a30-42ac-bfdb-3d12a65230b8
       X-Runtime:
-      - '0.022167'
+      - '0.016197'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:08 GMT
+  recorded_at: Fri, 16 May 2014 07:49:54 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:16 GMT
+      - Fri, 16 May 2014 07:49:52 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 1fd26572-86f8-49a1-9a0c-5658e34a1c00
+      - 7859ef5d-cfca-46c1-b184-7a32b59355b4
       X-Runtime:
-      - '0.020523'
+      - '0.021335'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:16 GMT
+  recorded_at: Fri, 16 May 2014 07:49:52 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:10 GMT
+      - Fri, 16 May 2014 07:49:51 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - f2ee4fdf-5a63-45b2-bcfd-f588fe208673
+      - 76021dd9-d580-4865-bb67-0b493b586d56
       X-Runtime:
-      - '0.023675'
+      - '0.054277'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Content-Length:
-      - '1749'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -59,13 +58,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -78,35 +78,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:10 GMT
+  recorded_at: Fri, 16 May 2014 07:49:51 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,25 +23,25 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:36 GMT
+      - Fri, 16 May 2014 18:43:26 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - a6ab21a1-4060-4c45-974b-564ade1e86de
+      - 973e9ba7-4060-4a4f-ab98-5296108d4f3d
       X-Runtime:
-      - '0.078244'
-      Transfer-Encoding:
-      - chunked
+      - '0.051801'
+      Content-Length:
+      - '1651'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: '{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
-        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"admin_emails":["foo@bar.com"],"contacts":[{"id":29,"name":"Suzanne
         Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
@@ -61,25 +59,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-16T11:37:41.659-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -97,13 +77,31 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
         Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:36 GMT
+  recorded_at: Fri, 16 May 2014 18:43:26 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -112,8 +110,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -126,17 +122,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:36 GMT
+      - Fri, 16 May 2014 18:43:27 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 82dab840-726b-4f2d-aeac-557654c3abcb
+      - d46feeb6-1de5-4c80-bc53-9476c0aa7ce8
       X-Runtime:
-      - '0.091295'
+      - '0.047102'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -144,7 +140,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
-        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"admin_emails":["foo@bar.com"],"contacts":[{"id":29,"name":"Suzanne
         Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
@@ -162,25 +158,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-16T11:37:41.659-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -198,8 +176,26 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
         Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:36 GMT
+  recorded_at: Fri, 16 May 2014 18:43:27 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/foobar?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,17 +23,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:37 GMT
+      - Fri, 16 May 2014 07:47:53 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 404 Not Found
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 0fcda499-8133-469c-9a3b-43ee026c9229
+      - 9b5e81d7-07f6-4856-adb4-7bc936238e91
       X-Runtime:
-      - '0.014382'
+      - '0.018348'
       Content-Length:
       - '76'
       Connection:
@@ -45,5 +43,5 @@ http_interactions:
       string: '{"error":"Not Found","message":"The requested resource could not be
         found."}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:38 GMT
+  recorded_at: Fri, 16 May 2014 07:47:53 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_via_search_results/includes_address_elements.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_via_search_results/includes_address_elements.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,19 +23,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:43 GMT
+      - Fri, 16 May 2014 07:47:54 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 1486a453-898a-41bc-99fc-9d83658e9c47
+      - 05a29fbf-f1ac-4834-b916-7ff18812eb2f
       X-Runtime:
-      - '0.032404'
+      - '0.040999'
       X-Total-Count:
       - '1'
       X-Total-Pages:
@@ -48,110 +46,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:43 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:23:43 GMT
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 200 OK
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Request-Id:
-      - ef21345d-8ec4-4ab4-af89-2d6345107f5a
-      X-Runtime:
-      - '0.066544'
-      Content-Length:
-      - '1627'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
         Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
         Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
@@ -170,25 +65,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -206,13 +83,31 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:43 GMT
+  recorded_at: Fri, 16 May 2014 07:47:54 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -221,8 +116,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -235,17 +128,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:43 GMT
+      - Fri, 16 May 2014 07:47:54 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - e28aa01b-958d-4efd-848d-299449568816
+      - 7507beac-1f2f-43c0-9351-8c44ef27af5a
       X-Runtime:
-      - '0.068420'
+      - '0.035581'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -271,25 +164,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -307,8 +182,125 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
         Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:43 GMT
+  recorded_at: Fri, 16 May 2014 07:47:54 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 16 May 2014 07:47:54 GMT
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
+      Status:
+      - 200 OK
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      X-Request-Id:
+      - ad108f33-80e1-4b01-a852-28ac5d8e038c
+      X-Runtime:
+      - '0.036959'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
+    http_version: 
+  recorded_at: Fri, 16 May 2014 07:47:54 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/location_details/when_you_return_to_the_results_page_from_details_page/displays_the_same_search_results.yml
+++ b/spec/cassettes/location_details/when_you_return_to_the_results_page_from_details_page/displays_the_same_search_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:45 GMT
+      - Fri, 16 May 2014 07:47:58 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 5b4c87ff-ab44-4ced-8e1e-638cf4fd2de0
+      - a73dc6d7-8963-4928-a0d4-3fbe37b50bbf
       X-Runtime:
-      - '0.029885'
+      - '0.044164'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
       Content-Length:
-      - '1749'
+      - '1635'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -59,13 +58,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -78,40 +78,36 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:45 GMT
+  recorded_at: Fri, 16 May 2014 07:47:58 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
     body:
       encoding: US-ASCII
       string: ''
@@ -120,8 +116,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -134,17 +128,116 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:46 GMT
+      - Fri, 16 May 2014 07:47:59 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - b6431b52-2d7e-4a15-af82-aaa49f4b902b
+      - e2b74cd0-a061-46d8-8b57-f65b6f146f04
       X-Runtime:
-      - '0.102584'
+      - '0.045442'
+      Content-Length:
+      - '1631'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
+    http_version: 
+  recorded_at: Fri, 16 May 2014 07:47:59 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 16 May 2014 07:47:59 GMT
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
+      Status:
+      - 200 OK
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      X-Request-Id:
+      - d8fc61ac-c18b-49c5-a6ab-a413ddc73639
+      X-Runtime:
+      - '0.042942'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -170,25 +263,7 @@ http_interactions:
         Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
         372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
         THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
-        service and nonprofit businesses, the public, military facilities, schools
-        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
-        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -206,72 +281,7 @@ http_interactions:
         by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:46 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency?api_token=<API_TOKEN>
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:23:46 GMT
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 200 OK
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Request-Id:
-      - e4327765-4845-4fdb-a254-e33caaedc206
-      X-Runtime:
-      - '0.093511'
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
-        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
-        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
-        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
-        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
-        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
-        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
-        stops within 1 block","updated_at":"2014-04-18T12:49:47.857-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":23,"audience":"Second
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
         service and nonprofit businesses, the public, military facilities, schools
         and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
         IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -289,31 +299,13 @@ http_interactions:
         by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
         County","Contra Costa County","Marin County","San Francisco County","Santa
         Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
-        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
-        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
-        County","Contra Costa County","Marin County","San Francisco County","Santa
-        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
         Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:46 GMT
+  recorded_at: Fri, 16 May 2014 07:47:59 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -322,8 +314,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -336,19 +326,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:47 GMT
+      - Fri, 16 May 2014 07:48:00 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - d28e1419-4bab-4c56-9ab3-979ca05cd1c5
+      - 58e21d6c-e0f8-4e43-b170-63a01aa1e36d
       X-Runtime:
-      - '0.042925'
+      - '0.056072'
       X-Total-Count:
       - '1'
       X-Total-Pages:
@@ -359,8 +349,9 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -370,13 +361,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -389,35 +381,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:47 GMT
+  recorded_at: Fri, 16 May 2014 07:48:00 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/less_than_3_pages_in_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/less_than_3_pages_in_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:23 GMT
+      - Fri, 16 May 2014 07:48:14 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 869b7e71-8ebc-4de2-ac12-29e92ee6c753
+      - dee7c3d3-3bb8-4fd5-9481-64cbb7376211
       X-Runtime:
-      - '0.029604'
+      - '0.040726'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,70 +52,50 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:23 GMT
+  recorded_at: Fri, 16 May 2014 07:48:14 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=3&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=3&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,15 +116,15 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:24 GMT
+      - Fri, 16 May 2014 07:48:14 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=4&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=4&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -156,26 +132,48 @@ http_interactions:
       X-Next-Page:
       - '4'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Previous-Page:
       - '2'
       X-Request-Id:
-      - 35e6b4a5-7e01-481e-86d9-0626ce93251a
+      - 7489df9d-ccc3-48cd-9f31-1f21adb2eb79
       X-Runtime:
-      - '0.018912'
+      - '0.039257'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1223'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"id":"20","organization":{"id":6,"name":"Location with no phone","slug":"location-with-no-phone","created_at":"2014-04-18T12:32:12.124-07:00","updated_at":"2014-04-18T12:32:12.475-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"updated_at":"2014-04-18T12:32:12.272-07:00","mail_address":{"id":20,"location_id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
-        phone","name":"Location with no phone","created_at":"2014-04-18T12:32:12.179-07:00","slug":"location-with-no-phone","short_desc":"no
-        phone","url":"http://ohana-api-test.herokuapp.com/api/locations/20","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849532179],"highlight":null,"_explanation":null}]'
+      string: '[{"id":3,"address":{"id":3,"street":"24 Second Avenue","city":"San
+        Mateo","state":"CA","zip":"94403"},"contacts":[{"id":4,"name":"Howard Lader,
+        LCSW","title":"Manager, Senior Peer Counseling"}],"coordinates":[-122.3263232,37.5639394],"description":"Offers
+        supportive counseling services to San Mateo County residents age 55 or over.
+        Volunteer counselors are selected and professionally trained to help their
+        peers face the challenges and concerns of growing older.  Training provides
+        topics that include understanding depression, cultural competence, sexuality,
+        community resources, and other subjects that are relevant to working with
+        older adults. After completion of training, weekly supervision groups are
+        provided for the volunteer senior peer counselors, as well as quarterly in-service
+        training seminars. Peer counseling services are provided in English, Spanish,
+        Chinese (Cantonese and Mandarin), Tagalog, and to the lesbian, gay, bisexual,
+        transgender older adult community. Formerly known as Family Service Agency
+        of San Mateo County, Senior Peer Counseling.","faxes":[{"id":3,"number":"650
+        403-4303"}],"hours":"Any time that is convenient for the client and peer counselor","languages":["Chinese
+        (Cantonese)","Chinese (Mandarin)","Filipino (Tagalog)","Spanish"],"mail_address":{"id":3,"attention":"PFS
+        Senior Peer Counseling","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94403"},"name":"Senior
+        Peer Counseling","phones":[{"id":3,"department":"English","number":"650 403-4300"}],"short_desc":"Offers
+        supportive counseling services to older persons.","slug":"senior-peer-counseling","transportation":"Service
+        is provided in person''s home or at a mutually agreed upon location.","updated_at":"2014-05-09T20:49:18.871-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/3","services":[{"id":3,"audience":"Older
+        adults age 55 or over who can benefit from counseling","eligibility":"Resident
+        of San Mateo County age 55 or over","fees":"None.","funding_sources":["County","Donations","Grants"],"keywords":["Geriatric
+        Counseling","Older Adults","Gay, Lesbian, Bisexual, Transgender Individuals"],"how_to_apply":"Phone
+        for information (403-4300 Ext. 4322).","service_areas":["San Mateo County"],"wait":"Varies.","updated_at":"2014-04-18T12:31:56.008-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:24 GMT
+  recorded_at: Fri, 16 May 2014 07:48:15 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/less_than_3_pages_out_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/less_than_3_pages_out_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:22 GMT
+      - Fri, 16 May 2014 07:48:13 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - ec7c8148-d14c-4393-8d16-50df61132156
+      - 7f63575b-9a87-46b9-9900-0699a0bb81a9
       X-Runtime:
-      - '0.036610'
+      - '0.040257'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,146 +52,14 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:22 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:23:23 GMT
-      Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
-        rel="prev"
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 200 OK
-      X-Current-Page:
-      - '22'
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Previous-Page:
-      - '21'
-      X-Request-Id:
-      - e7d436ac-3c9f-4c9b-b846-197fb9c33283
-      X-Runtime:
-      - '0.019656'
-      X-Total-Count:
-      - '22'
-      X-Total-Pages:
-      - '22'
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '[{"services":[{"id":1,"audience":"Older adults age 55 or over, ethnic
-        minorities and low-income persons","eligibility":"Age 55 or over for most
-        programs, age 60 or over for lunch program","fees":"$2.50 suggested donation
-        for lunch for age 60 or over, donations for other services appreciated. Cash
-        and checks accepted.","how_to_apply":"Walk in or apply by phone.","wait":"No
-        wait.","funding_sources":["City","County","Donations","Fees","Fundraising"],"service_areas":["Redwood
-        City"],"keywords":["ADULT PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered
-        Mea","COMMUNITY SERVICES","Group Support","Information and Referral","EDUCATION
-        SERVICES","English Language","RECREATION/LEISURE SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown
-        Bag Food Programs","Congregate Meals/Nutrition Sites","Senior Centers","Older
-        Adults"],"updated_at":"2014-04-18T12:31:54.284-07:00"}],"mail_address":{"id":1,"location_id":1,"attention":"Fair
-        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
-        stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
-        780-7525"}],"contacts":[{"id":1,"location_id":1,"name":"Susan Houston","title":"Director
-        of Older Adult Services"},{"id":2,"location_id":1,"name":"Christina Gonzalez","title":"Center
-        Director"}],"id":"1","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:54.310-07:00","faxes":[{"id":1,"location_id":1,"number":"650
-        701-0856"}],"address":{"id":1,"location_id":1,"street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"description":"A walk-in center for older
-        adults that provides social services, wellness, recreational, educational
-        and creative activities including arts and crafts, computer classes and gardening
-        classes. Coffee and healthy breakfasts are available daily. A hot lunch is
-        served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
         case management (including in-home assessments) and bilingual information
         and referral about community services to persons age 60 or over on questions
         of housing, employment, household help, recreation and social activities,
@@ -208,14 +74,28 @@ http_interactions:
         groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
         Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
         Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
-        Agency of San Mateo County, Fair Oaks Intergenerational Center.","name":"Fair
-        Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849513696],"highlight":null,"_explanation":null}]'
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:23 GMT
+  recorded_at: Fri, 16 May 2014 07:48:13 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=20&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -224,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -238,15 +116,126 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:23 GMT
+      - Fri, 16 May 2014 07:48:14 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=19&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=21&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev"
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
+      Status:
+      - 200 OK
+      X-Current-Page:
+      - '22'
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      X-Previous-Page:
+      - '21'
+      X-Request-Id:
+      - debfdb4b-2c5f-4d7a-acac-6034e29292c5
+      X-Runtime:
+      - '0.042453'
+      X-Total-Count:
+      - '22'
+      X-Total-Pages:
+      - '22'
+      Content-Length:
+      - '1635'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
+    http_version: 
+  recorded_at: Fri, 16 May 2014 07:48:14 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=20&service_area=&utf8=%E2%9C%93
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 16 May 2014 07:48:14 GMT
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=19&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=21&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -254,50 +243,26 @@ http_interactions:
       X-Next-Page:
       - '21'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Previous-Page:
       - '19'
       X-Request-Id:
-      - b7d7c39e-5248-45d3-a6ad-8386738191e4
+      - 1f8cacdf-8106-4c82-af07-338168f97c26
       X-Runtime:
-      - '0.035428'
+      - '0.035724'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '308'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":3,"audience":"Older adults age 55 or over who can
-        benefit from counseling","eligibility":"Resident of San Mateo County age 55
-        or over","fees":"None.","how_to_apply":"Phone for information (403-4300 Ext.
-        4322).","wait":"Varies.","funding_sources":["County","Donations","Grants"],"service_areas":["San
-        Mateo County"],"keywords":["Geriatric Counseling","Older Adults","Gay, Lesbian,
-        Bisexual, Transgender Individuals"],"updated_at":"2014-04-18T12:31:56.008-07:00"}],"mail_address":{"id":3,"location_id":3,"attention":"PFS
-        Senior Peer Counseling","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Any
-        time that is convenient for the client and peer counselor","transportation":"Service
-        is provided in person''s home or at a mutually agreed upon location.","short_desc":"Offers
-        supportive counseling services to older persons.","url":"http://ohana-api-test.herokuapp.com/api/locations/3","phones":[{"id":3,"location_id":3,"number":"650
-        403-4300","department":"English"}],"contacts":[{"id":4,"location_id":3,"name":"Howard
-        Lader, LCSW","title":"Manager, Senior Peer Counseling"}],"id":"3","languages":["Chinese
-        (Cantonese)","Chinese (Mandarin)","Filipino (Tagalog)","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:56.019-07:00","faxes":[{"id":3,"location_id":3,"number":"650
-        403-4303"}],"address":{"id":3,"location_id":3,"street":"24 Second Avenue","city":"San
-        Mateo","state":"CA","zip":"94403"},"description":"Offers supportive counseling
-        services to San Mateo County residents age 55 or over. Volunteer counselors
-        are selected and professionally trained to help their peers face the challenges
-        and concerns of growing older.  Training provides topics that include understanding
-        depression, cultural competence, sexuality, community resources, and other
-        subjects that are relevant to working with older adults. After completion
-        of training, weekly supervision groups are provided for the volunteer senior
-        peer counselors, as well as quarterly in-service training seminars. Peer counseling
-        services are provided in English, Spanish, Chinese (Cantonese and Mandarin),
-        Tagalog, and to the lesbian, gay, bisexual, transgender older adult community.
-        Formerly known as Family Service Agency of San Mateo County, Senior Peer Counseling.","name":"Senior
-        Peer Counseling","created_at":"2014-04-18T12:31:55.530-07:00","longitude":-122.3263232,"slug":"senior-peer-counseling","latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849515530],"highlight":null,"_explanation":null}]'
+      string: '[{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
+        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:23 GMT
+  recorded_at: Fri, 16 May 2014 07:48:14 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/more_than_3_pages_in_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/more_than_3_pages_in_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:22 GMT
+      - Fri, 16 May 2014 07:48:11 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - b21adfe5-82d6-4990-9f5c-87a3a9b787ab
+      - 9b4ede07-b63e-4633-91d9-f19fa4e2bf47
       X-Runtime:
-      - '0.025088'
+      - '0.053912'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,70 +52,50 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:22 GMT
+  recorded_at: Fri, 16 May 2014 07:48:11 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=4&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=4&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,15 +116,15 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:22 GMT
+      - Fri, 16 May 2014 07:48:11 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=5&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=3&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=5&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -156,13 +132,13 @@ http_interactions:
       X-Next-Page:
       - '5'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Previous-Page:
       - '3'
       X-Request-Id:
-      - aba5bade-1f83-45a0-bdb2-e31244655ddf
+      - 9a7e8aa6-3ee9-4358-a440-adf61d9f4187
       X-Runtime:
-      - '0.034297'
+      - '0.048716'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -173,21 +149,35 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":19,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment
-        (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
-        City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:11.921-07:00"}],"mail_address":{"id":19,"location_id":19,"attention":"San
-        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
-        9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":19,"location_id":19,"number":"650
-        578-0400"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:11.939-07:00","faxes":[{"id":19,"location_id":19,"number":"650
-        578-0440"}],"address":{"id":19,"location_id":19,"street":"19 West 39th Avenue","city":"San
-        Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
-        dental care to those in need. Offers basic medical care for adults.","name":"San
-        Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849531266],"highlight":null,"_explanation":null}]'
+      string: '[{"id":4,"accessibility":["Wheelchair"],"address":{"id":4,"street":"24
+        Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"contacts":[{"id":5,"name":"Kimberly
+        Pesavento","title":"Director of Visitation"}],"coordinates":[-122.3263232,37.5639394],"description":"Provides
+        supervised visitation services and a neutral site for parents to carry out
+        supervised exchanges of children in a safe manner. Therapeutic visitation
+        and other counseling services available. Kids in the Middle is an education
+        class for separating or divorcing parents. The goal is to enable parents to
+        focus on their children''s needs while the family is going through separation,
+        divorce or other transition. The class explores the psychological aspects
+        of divorce and its impact on children, builds effective communication techniques
+        and points out areas in which outside help may be indicated. The fee is $50
+        for working parents, $15 for unemployed people. Classes are scheduled on Saturdays
+        and Sundays and held at various sites throughout the county. Call 650-403-4300
+        ext. 4500 to register. Formerly known as Family Service Agency of San Mateo
+        County, Family Visitation Center.","emails":["kpesavento@peninsulafamilyservice.org"],"faxes":[{"id":4,"number":"650
+        403-4303"}],"hours":"Monday, 10-6; Tuesday-Friday, 10-8; Saturday, Sunday,
+        9:30-5:30","languages":["Spanish"],"mail_address":{"id":4,"attention":"PFS
+        Family Visitation Center","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"name":"Family
+        Visitation Center","phones":[{"id":4,"extension":"4500","number":"650 403-4300"}],"short_desc":"Provides
+        supervised visitation services and a neutral site for parents in extremely
+        hostile divorces to carry out supervised exchanges of children.","slug":"family-visitation-center","transportation":"SAMTRANS
+        stops within 1 block, CALTRAIN stops within 4 blocks.","updated_at":"2014-05-09T20:49:18.878-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/4","services":[{"id":4,"audience":"Parents,
+        children, families with problems of custody disputes, domestic violence or
+        substance abuse, families going through a separation or divorce","eligibility":"None","fees":"Vary
+        according to income ($5-$90). Cash, checks and credit cards accepted.","funding_sources":["County","Donations","Grants"],"keywords":["INDIVIDUAL
+        AND FAMILY DEVELOPMENT SERVICES","Growth and Adjustment","LEGAL AND CRIMINAL
+        JUSTICE SERVICES","Mediation","Parental Visitation Monitoring","Divorce Counseling","Youth"],"how_to_apply":"Apply
+        by phone.","service_areas":["San Mateo County"],"wait":"No wait.","updated_at":"2014-04-18T12:31:56.923-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:22 GMT
+  recorded_at: Fri, 16 May 2014 07:48:11 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/more_than_3_pages_out_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/more_than_3_pages_out_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:21 GMT
+      - Fri, 16 May 2014 07:48:15 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 51b17ece-a8c1-4137-bbb4-7457e4819afa
+      - a9ad22e9-904e-416a-8705-73ea66a2081f
       X-Runtime:
-      - '0.021685'
+      - '0.043757'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,146 +52,14 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:21 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:23:21 GMT
-      Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
-        rel="prev"
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 200 OK
-      X-Current-Page:
-      - '22'
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Previous-Page:
-      - '21'
-      X-Request-Id:
-      - 2e8b7b2e-9030-45ec-9187-5451234726c6
-      X-Runtime:
-      - '0.024437'
-      X-Total-Count:
-      - '22'
-      X-Total-Pages:
-      - '22'
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '[{"services":[{"id":1,"audience":"Older adults age 55 or over, ethnic
-        minorities and low-income persons","eligibility":"Age 55 or over for most
-        programs, age 60 or over for lunch program","fees":"$2.50 suggested donation
-        for lunch for age 60 or over, donations for other services appreciated. Cash
-        and checks accepted.","how_to_apply":"Walk in or apply by phone.","wait":"No
-        wait.","funding_sources":["City","County","Donations","Fees","Fundraising"],"service_areas":["Redwood
-        City"],"keywords":["ADULT PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered
-        Mea","COMMUNITY SERVICES","Group Support","Information and Referral","EDUCATION
-        SERVICES","English Language","RECREATION/LEISURE SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown
-        Bag Food Programs","Congregate Meals/Nutrition Sites","Senior Centers","Older
-        Adults"],"updated_at":"2014-04-18T12:31:54.284-07:00"}],"mail_address":{"id":1,"location_id":1,"attention":"Fair
-        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
-        stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
-        780-7525"}],"contacts":[{"id":1,"location_id":1,"name":"Susan Houston","title":"Director
-        of Older Adult Services"},{"id":2,"location_id":1,"name":"Christina Gonzalez","title":"Center
-        Director"}],"id":"1","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:54.310-07:00","faxes":[{"id":1,"location_id":1,"number":"650
-        701-0856"}],"address":{"id":1,"location_id":1,"street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"description":"A walk-in center for older
-        adults that provides social services, wellness, recreational, educational
-        and creative activities including arts and crafts, computer classes and gardening
-        classes. Coffee and healthy breakfasts are available daily. A hot lunch is
-        served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
         case management (including in-home assessments) and bilingual information
         and referral about community services to persons age 60 or over on questions
         of housing, employment, household help, recreation and social activities,
@@ -208,14 +74,28 @@ http_interactions:
         groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
         Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
         Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
-        Agency of San Mateo County, Fair Oaks Intergenerational Center.","name":"Fair
-        Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849513696],"highlight":null,"_explanation":null}]'
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:21 GMT
+  recorded_at: Fri, 16 May 2014 07:48:15 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=18&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -224,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -238,29 +116,25 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:21 GMT
+      - Fri, 16 May 2014 07:48:15 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=17&service_area=&utf8=%E2%9C%93>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=19&service_area=&utf8=%E2%9C%93>;
-        rel="next"
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=21&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
-      - '18'
-      X-Next-Page:
-      - '19'
+      - '22'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Previous-Page:
-      - '17'
+      - '21'
       X-Request-Id:
-      - 16b9403d-cde6-4f57-b59c-c2d33eec8cce
+      - 6dd523d7-d509-46c8-9a62-e62633204280
       X-Runtime:
-      - '0.020775'
+      - '0.055267'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -271,31 +145,139 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":5,"audience":"Target group: Low-income working
-        families with children transitioning from welfare to work and poor or who
-        do not have access to conventional credit","eligibility":"Eligibility: Low-income
-        family with legal custody of a minor child or an involved parent of a dependent
-        minor child. Must reside and/or work in San Mateo County. Must be working
-        and have verifiable income and ability to pay off loan. No bankruptcies in
-        the past two years and unable to qualify for other funding sources. Loans
-        approved by loan committee.","fees":"$60 application fee. Cash or checks accepted.","how_to_apply":"Phone
-        for information.","funding_sources":["County","Grants","State"],"service_areas":["San
-        Mateo County"],"keywords":["COMMUNITY SERVICES","Speakers","Automobile Loans"],"updated_at":"2014-04-18T12:31:57.657-07:00"}],"mail_address":{"id":5,"location_id":5,"attention":"Economic
-        Self - Sufficiency Program","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"urls":["http://www.peninsulafamilyservice.org"],"emails":["waystowork@peninsulafamilyservice.org"],"transportation":"SAMTRANS
-        stops within 1 block. CALTRAIN stops within 6 blocks.","short_desc":"Makes
-        small loans to working families.","url":"http://ohana-api-test.herokuapp.com/api/locations/5","phones":[{"id":5,"location_id":5,"number":"650
-        403-4300","extension":"4100"}],"contacts":[{"id":6,"location_id":5,"name":"Joe
-        Bloom","title":"Financial Empowerment Programs Program Director"}],"id":"5","languages":["Hindi","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:57.680-07:00","faxes":[{"id":5,"location_id":5,"number":"650
-        403-4303"}],"address":{"id":5,"location_id":5,"street":"24 Second Avenue","city":"San
-        Mateo","state":"CA","zip":"94401"},"description":"Provides fixed 8% short
-        term loans to eligible applicants for the purchase of a reliable, used autmobile.
-        Loans are up to $6,000 over 2 1/2 years (30 months). Funds must go towards
-        the entire purchase of the automobile. Peninsula Family Service originates
-        loans and collaborates with commercial partner banks to service the loans,
-        helping clients build credit histories. Formerly known as Family Service Agency
-        of San Mateo County, Ways to Work Family Loan Program.","name":"Economic Self
-        - Sufficiency Program","created_at":"2014-04-18T12:31:57.166-07:00","longitude":-122.3263232,"slug":"economic-self-sufficiency-program","latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849517166],"highlight":null,"_explanation":null}]'
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:21 GMT
+  recorded_at: Fri, 16 May 2014 07:48:15 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=18&service_area=&utf8=%E2%9C%93
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 16 May 2014 07:48:16 GMT
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=17&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=19&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="next"
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
+      Status:
+      - 200 OK
+      X-Current-Page:
+      - '18'
+      X-Next-Page:
+      - '19'
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      X-Previous-Page:
+      - '17'
+      X-Request-Id:
+      - f2deb494-644d-4bf8-83c3-26698c065248
+      X-Runtime:
+      - '0.053943'
+      X-Total-Count:
+      - '22'
+      X-Total-Pages:
+      - '22'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":18,"accessibility":["Disabled Restroom","Wheelchair"],"address":{"id":18,"street":"114
+        Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":26,"name":"Sharon
+        Petersen","title":"Administrator"}],"coordinates":[-122.207057,37.468678],"description":"Provides
+        free medical care to those in need. Offers basic medical exams for adults
+        and tuberculosis screening. Assists the individual to access other services
+        in the community. By appointment only, Project Smile provides a free dental
+        exam, dental cleaning and oral hygiene instruction for children, age 3-12,
+        of Samaritan House clients.","emails":["gracie@samaritanhouse.com"],"faxes":[{"id":18,"number":"650
+        839-1457"}],"hours":"Monday-Friday, 9-12, 2-5","languages":["Spanish"],"mail_address":{"id":18,"attention":"Redwood
+        City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"name":"Redwood
+        City Free Medical Clinic","phones":[{"id":18,"number":"650 839-1447"}],"short_desc":"Provides
+        free medical care to those in need.","slug":"redwood-city-free-medical-clinic","transportation":"SAMTRANS
+        stops within 2 blocks.","updated_at":"2014-05-09T20:49:18.967-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/18","services":[{"id":18,"eligibility":"Low-income
+        person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
+        SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
+        screening appointment. Medical visits are by appointment only.","service_areas":["Atherton","East
+        Palo Alto","Menlo Park","Redwood City","San Carlos"],"wait":"Varies.","updated_at":"2014-04-18T12:32:10.649-07:00"}],"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}]'
+    http_version: 
+  recorded_at: Fri, 16 May 2014 07:48:16 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_first_page_with_less_than_4_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_first_page_with_less_than_4_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:25 GMT
+      - Fri, 16 May 2014 07:48:11 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=3&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - f0a0abc6-f127-4b02-ba02-57454bbba0ba
+      - 9ac0a1b6-e134-4f00-af1d-5dcb09dc3a22
       X-Runtime:
-      - '0.029641'
+      - '0.043368'
       X-Total-Count:
       - '3'
       X-Total-Pages:
@@ -54,22 +52,9 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":12,"audience":"Adults, parents, children in 1st-12th
-        grades in the Redwood City school districta","eligibility":"English-speaking
-        adult reading at or below 7th grade level or child in 1st-12th grade in the
-        Redwood City school districts","fees":"None.","how_to_apply":"Walk in or apply
-        by phone, email or webpage registration.","wait":"Depends on availability
-        of tutors for small groups and one-on-one.","funding_sources":["City","Donations","Federal","Grants","State"],"service_areas":["Redwood
-        City"],"keywords":["EDUCATION SERVICES","Adult","Alternative","Literacy","Literacy
-        Programs","Libraries","Public Libraries","Youth"],"updated_at":"2014-04-18T12:32:04.768-07:00"}],"mail_address":{"id":12,"location_id":12,"attention":"Project
-        Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
-        10-8:30; Friday, 10-5","urls":["http://www.projectreadredwoodcity.org"],"emails":["rclread@redwoodcity.org"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Offers an intergenerational literacy
-        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-test.herokuapp.com/api/locations/12","phones":[{"id":12,"location_id":12,"number":"650
-        780-7077"}],"contacts":[{"id":20,"location_id":12,"name":"Kathy Endaya","title":"Director"}],"id":"12","organization":{"id":3,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-18T12:32:01.230-07:00","updated_at":"2014-04-18T12:32:05.849-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-18T12:32:04.803-07:00","faxes":[{"id":12,"location_id":12,"number":"650
-        780-7004"}],"address":{"id":12,"location_id":12,"street":"1044 Middlefield
-        Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"description":"Offers
+      string: '[{"id":12,"accessibility":["Elevator","Ramp","Disabled Restroom","Disabled
+        Parking"],"address":{"id":12,"street":"1044 Middlefield Road, 2nd Floor","city":"Redwood
+        City","state":"CA","zip":"94063"},"contacts":[{"id":20,"name":"Kathy Endaya","title":"Director"}],"coordinates":[-122.227409,37.4837662],"description":"Offers
         an intergenerational literacy program for youth and English-speaking adults
         seeking to improver literacy skills. Adult services include: adult one-to-one
         tutoring to improve basic skills in reading, writing and critical thinking;
@@ -79,8 +64,21 @@ http_interactions:
         in Partnership (FIP); Teen-to-Elementary Student Tutoring, Kids in Partnership
         (KIP); and computer-aided literacy. Redwood City Friends of Literacy is a
         fundraising board that helps to support and to fund Redwood City''s Project
-        Read. Call for more information about each service.","name":"Project Read","created_at":"2014-04-18T12:32:03.900-07:00","longitude":-122.227409,"slug":"project-read","latitude":37.4837662,"coordinates":[-122.227409,37.4837662],"accessibility":["Elevator","Ramp","Disabled
-        Restroom","Disabled Parking"],"_score":0.010318076,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Read. Call for more information about each service.","emails":["rclread@redwoodcity.org"],"faxes":[{"id":12,"number":"650
+        780-7004"}],"hours":"Monday-Thursday, 10-8:30; Friday, 10-5","mail_address":{"id":12,"attention":"Project
+        Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"name":"Project
+        Read","phones":[{"id":12,"number":"650 780-7077"}],"short_desc":"Offers an
+        intergenerational literacy program for adults and youth seeking to improver
+        literacy skills.","slug":"project-read","transportation":"SAMTRANS stops within
+        1 block.","updated_at":"2014-05-09T20:49:18.932-07:00","urls":["http://www.projectreadredwoodcity.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/12","services":[{"id":12,"audience":"Adults,
+        parents, children in 1st-12th grades in the Redwood City school districta","eligibility":"English-speaking
+        adult reading at or below 7th grade level or child in 1st-12th grade in the
+        Redwood City school districts","fees":"None.","funding_sources":["City","Donations","Federal","Grants","State"],"keywords":["EDUCATION
+        SERVICES","Adult","Alternative","Literacy","Literacy Programs","Libraries","Public
+        Libraries","Youth"],"how_to_apply":"Walk in or apply by phone, email or webpage
+        registration.","service_areas":["Redwood City"],"wait":"Depends on availability
+        of tutors for small groups and one-on-one.","updated_at":"2014-04-18T12:32:04.768-07:00"}],"organization":{"id":3,"name":"Redwood
+        City Public Library","slug":"redwood-city-public-library","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:25 GMT
+  recorded_at: Fri, 16 May 2014 07:48:11 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_first_page_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_first_page_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:25 GMT
+      - Fri, 16 May 2014 07:48:12 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4499bfe4-0546-46bd-bf4b-cba0de5f2d92
+      - 89784ff4-7063-4ce9-91d2-eb8e50078ccf
       X-Runtime:
-      - '0.049854'
+      - '0.094491'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,65 +52,45 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:25 GMT
+  recorded_at: Fri, 16 May 2014 07:48:12 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_last_page_with_less_than_4_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_last_page_with_less_than_4_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:24 GMT
+      - Fri, 16 May 2014 07:48:13 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=3&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,37 +37,24 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4b602f61-bf99-4017-be02-845ee413f59d
+      - 1b6dd150-0441-4bde-92a3-0d40795a2146
       X-Runtime:
-      - '0.030128'
+      - '0.040945'
       X-Total-Count:
       - '3'
       X-Total-Pages:
       - '3'
       Content-Length:
-      - '1433'
+      - '1303'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":12,"audience":"Adults, parents, children in 1st-12th
-        grades in the Redwood City school districta","eligibility":"English-speaking
-        adult reading at or below 7th grade level or child in 1st-12th grade in the
-        Redwood City school districts","fees":"None.","how_to_apply":"Walk in or apply
-        by phone, email or webpage registration.","wait":"Depends on availability
-        of tutors for small groups and one-on-one.","funding_sources":["City","Donations","Federal","Grants","State"],"service_areas":["Redwood
-        City"],"keywords":["EDUCATION SERVICES","Adult","Alternative","Literacy","Literacy
-        Programs","Libraries","Public Libraries","Youth"],"updated_at":"2014-04-18T12:32:04.768-07:00"}],"mail_address":{"id":12,"location_id":12,"attention":"Project
-        Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Thursday,
-        10-8:30; Friday, 10-5","urls":["http://www.projectreadredwoodcity.org"],"emails":["rclread@redwoodcity.org"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Offers an intergenerational literacy
-        program for adults and youth seeking to improver literacy skills.","url":"http://ohana-api-test.herokuapp.com/api/locations/12","phones":[{"id":12,"location_id":12,"number":"650
-        780-7077"}],"contacts":[{"id":20,"location_id":12,"name":"Kathy Endaya","title":"Director"}],"id":"12","organization":{"id":3,"name":"Redwood
-        City Public Library","slug":"redwood-city-public-library","created_at":"2014-04-18T12:32:01.230-07:00","updated_at":"2014-04-18T12:32:05.849-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"},"updated_at":"2014-04-18T12:32:04.803-07:00","faxes":[{"id":12,"location_id":12,"number":"650
-        780-7004"}],"address":{"id":12,"location_id":12,"street":"1044 Middlefield
-        Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"description":"Offers
+      string: '[{"id":12,"accessibility":["Elevator","Ramp","Disabled Restroom","Disabled
+        Parking"],"address":{"id":12,"street":"1044 Middlefield Road, 2nd Floor","city":"Redwood
+        City","state":"CA","zip":"94063"},"contacts":[{"id":20,"name":"Kathy Endaya","title":"Director"}],"coordinates":[-122.227409,37.4837662],"description":"Offers
         an intergenerational literacy program for youth and English-speaking adults
         seeking to improver literacy skills. Adult services include: adult one-to-one
         tutoring to improve basic skills in reading, writing and critical thinking;
@@ -79,13 +64,26 @@ http_interactions:
         in Partnership (FIP); Teen-to-Elementary Student Tutoring, Kids in Partnership
         (KIP); and computer-aided literacy. Redwood City Friends of Literacy is a
         fundraising board that helps to support and to fund Redwood City''s Project
-        Read. Call for more information about each service.","name":"Project Read","created_at":"2014-04-18T12:32:03.900-07:00","longitude":-122.227409,"slug":"project-read","latitude":37.4837662,"coordinates":[-122.227409,37.4837662],"accessibility":["Elevator","Ramp","Disabled
-        Restroom","Disabled Parking"],"_score":0.010318076,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Read. Call for more information about each service.","emails":["rclread@redwoodcity.org"],"faxes":[{"id":12,"number":"650
+        780-7004"}],"hours":"Monday-Thursday, 10-8:30; Friday, 10-5","mail_address":{"id":12,"attention":"Project
+        Read","street":"1044 Middlefield Road, 2nd Floor","city":"Redwood City","state":"CA","zip":"94063"},"name":"Project
+        Read","phones":[{"id":12,"number":"650 780-7077"}],"short_desc":"Offers an
+        intergenerational literacy program for adults and youth seeking to improver
+        literacy skills.","slug":"project-read","transportation":"SAMTRANS stops within
+        1 block.","updated_at":"2014-05-09T20:49:18.932-07:00","urls":["http://www.projectreadredwoodcity.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/12","services":[{"id":12,"audience":"Adults,
+        parents, children in 1st-12th grades in the Redwood City school districta","eligibility":"English-speaking
+        adult reading at or below 7th grade level or child in 1st-12th grade in the
+        Redwood City school districts","fees":"None.","funding_sources":["City","Donations","Federal","Grants","State"],"keywords":["EDUCATION
+        SERVICES","Adult","Alternative","Literacy","Literacy Programs","Libraries","Public
+        Libraries","Youth"],"how_to_apply":"Walk in or apply by phone, email or webpage
+        registration.","service_areas":["Redwood City"],"wait":"Depends on availability
+        of tutors for small groups and one-on-one.","updated_at":"2014-04-18T12:32:04.768-07:00"}],"organization":{"id":3,"name":"Redwood
+        City Public Library","slug":"redwood-city-public-library","url":"http://ohana-api-test.herokuapp.com/api/organizations/3","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/3/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:24 GMT
+  recorded_at: Fri, 16 May 2014 07:48:13 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=3&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -94,8 +92,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -108,57 +104,64 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:24 GMT
+      - Fri, 16 May 2014 07:48:13 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=youth&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=youth&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="prev"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '3'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Previous-Page:
       - '2'
       X-Request-Id:
-      - a264e0b0-a3d1-4cf4-bdd9-af3c748fcc16
+      - 06054e5a-fe30-4258-b618-cfd476187976
       X-Runtime:
-      - '0.022151'
+      - '0.039070'
       X-Total-Count:
       - '3'
       X-Total-Pages:
       - '3'
       Content-Length:
-      - '1262'
+      - '1455'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":16,"eligibility":"None for emergency assistance","fees":"None
-        for emergency services. Vary for after school activities. Cash and checks
-        accepted.","how_to_apply":"Walk in. Written application, identification required
-        for emergency assistance.","wait":"No wait.","funding_sources":["Donations","Fees","Grants"],"service_areas":["Los
-        Altos","Mountain View","Sunnyvale"],"keywords":["COMMODITY SERVICES","Clothing/Personal
-        Items","CHILD PROTECTION AND CARE SERVICES","Day Care","COMMUNITY SERVICES","Information
-        and Referral","EMERGENCY SERVICES","Food Boxes/Food Vouchers","FINANCIAL ASSISTANCE
-        SERVICES","Utilities","RECREATION/LEISURE SERVICES","Camping","Emergency Food","Clothing","Utility
-        Assistance","Youth Development"],"updated_at":"2014-04-18T12:32:08.629-07:00"}],"mail_address":{"id":16,"location_id":16,"attention":"Salvation
-        Army","street":"P.O. Box 61868","city":"Sunnyvale","state":"CA","zip":"94088"},"hours":"Monday-Friday,
-        9-4","emails":["william_nichols@usw.salvationarmy.org"],"transportation":"VTA
-        stops within 4 blocks.","short_desc":"Provides emergency assistance to persons
-        in immediate need and offers after school activities and summer day camp program.","url":"http://ohana-api-test.herokuapp.com/api/locations/16","phones":[{"id":16,"location_id":16,"number":"408
-        720-0420"}],"contacts":[{"id":24,"location_id":16,"name":"James Lee","title":"Commanding
-        Officer"}],"id":"16","languages":["Korean"],"organization":{"id":4,"name":"Salvation
-        Army","slug":"salvation-army","created_at":"2014-04-18T12:32:05.934-07:00","updated_at":"2014-04-18T12:32:09.483-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/4","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/4/locations"},"updated_at":"2014-04-18T12:32:08.639-07:00","faxes":[{"id":15,"location_id":16,"number":"408
-        720-8075"}],"address":{"id":16,"location_id":16,"street":"1161 South Bernardo","city":"Sunnyvale","state":"CA","zip":"94087"},"description":"Provides
-        emergency assistance including food and clothing for persons in immediate
-        need. Provides PG\u0026E assistance through REACH program. Youth programs
-        offer tutoring, music and troops. Information on related resources is available.
-        Also provides rental assistance when funds are available.","name":"Sunnyvale
-        Corps","created_at":"2014-04-18T12:32:08.088-07:00","longitude":-122.0600024,"slug":"sunnyvale-corps","latitude":37.3569004,"coordinates":[-122.0600024,37.3569004],"_score":0.007738203,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+      string: '[{"id":4,"accessibility":["Wheelchair"],"address":{"id":4,"street":"24
+        Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"contacts":[{"id":5,"name":"Kimberly
+        Pesavento","title":"Director of Visitation"}],"coordinates":[-122.3263232,37.5639394],"description":"Provides
+        supervised visitation services and a neutral site for parents to carry out
+        supervised exchanges of children in a safe manner. Therapeutic visitation
+        and other counseling services available. Kids in the Middle is an education
+        class for separating or divorcing parents. The goal is to enable parents to
+        focus on their children''s needs while the family is going through separation,
+        divorce or other transition. The class explores the psychological aspects
+        of divorce and its impact on children, builds effective communication techniques
+        and points out areas in which outside help may be indicated. The fee is $50
+        for working parents, $15 for unemployed people. Classes are scheduled on Saturdays
+        and Sundays and held at various sites throughout the county. Call 650-403-4300
+        ext. 4500 to register. Formerly known as Family Service Agency of San Mateo
+        County, Family Visitation Center.","emails":["kpesavento@peninsulafamilyservice.org"],"faxes":[{"id":4,"number":"650
+        403-4303"}],"hours":"Monday, 10-6; Tuesday-Friday, 10-8; Saturday, Sunday,
+        9:30-5:30","languages":["Spanish"],"mail_address":{"id":4,"attention":"PFS
+        Family Visitation Center","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"name":"Family
+        Visitation Center","phones":[{"id":4,"extension":"4500","number":"650 403-4300"}],"short_desc":"Provides
+        supervised visitation services and a neutral site for parents in extremely
+        hostile divorces to carry out supervised exchanges of children.","slug":"family-visitation-center","transportation":"SAMTRANS
+        stops within 1 block, CALTRAIN stops within 4 blocks.","updated_at":"2014-05-09T20:49:18.878-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/4","services":[{"id":4,"audience":"Parents,
+        children, families with problems of custody disputes, domestic violence or
+        substance abuse, families going through a separation or divorce","eligibility":"None","fees":"Vary
+        according to income ($5-$90). Cash, checks and credit cards accepted.","funding_sources":["County","Donations","Grants"],"keywords":["INDIVIDUAL
+        AND FAMILY DEVELOPMENT SERVICES","Growth and Adjustment","LEGAL AND CRIMINAL
+        JUSTICE SERVICES","Mediation","Parental Visitation Monitoring","Divorce Counseling","Youth"],"how_to_apply":"Apply
+        by phone.","service_areas":["San Mateo County"],"wait":"No wait.","updated_at":"2014-04-18T12:31:56.923-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:24 GMT
+  recorded_at: Fri, 16 May 2014 07:48:13 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/on_last_page_with_more_than_5_pages_of_results.yml
+++ b/spec/cassettes/results_page_pagination/on_last_page_with_more_than_5_pages_of_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:25 GMT
+      - Fri, 16 May 2014 07:48:12 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 8c16c92a-b1a0-4515-86db-911ffa3317f0
+      - 91036cc7-cd98-4c9d-9cb9-ff0794230961
       X-Runtime:
-      - '0.064706'
+      - '0.044301'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,146 +52,14 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:25 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:23:26 GMT
-      Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=1&service_area=&utf8=%E2%9C%93>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=21&service_area=&utf8=%E2%9C%93>;
-        rel="prev"
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 200 OK
-      X-Current-Page:
-      - '22'
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Previous-Page:
-      - '21'
-      X-Request-Id:
-      - dbfbf1a4-4d36-4307-b853-4ba2cac71e64
-      X-Runtime:
-      - '0.043938'
-      X-Total-Count:
-      - '22'
-      X-Total-Pages:
-      - '22'
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '[{"services":[{"id":1,"audience":"Older adults age 55 or over, ethnic
-        minorities and low-income persons","eligibility":"Age 55 or over for most
-        programs, age 60 or over for lunch program","fees":"$2.50 suggested donation
-        for lunch for age 60 or over, donations for other services appreciated. Cash
-        and checks accepted.","how_to_apply":"Walk in or apply by phone.","wait":"No
-        wait.","funding_sources":["City","County","Donations","Fees","Fundraising"],"service_areas":["Redwood
-        City"],"keywords":["ADULT PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered
-        Mea","COMMUNITY SERVICES","Group Support","Information and Referral","EDUCATION
-        SERVICES","English Language","RECREATION/LEISURE SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown
-        Bag Food Programs","Congregate Meals/Nutrition Sites","Senior Centers","Older
-        Adults"],"updated_at":"2014-04-18T12:31:54.284-07:00"}],"mail_address":{"id":1,"location_id":1,"attention":"Fair
-        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"hours":"Monday-Friday, 9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["cgonzalez@peninsulafamilyservice.org"],"transportation":"SAMTRANS
-        stops in front.","short_desc":"A multipurpose senior citizens'' center serving
-        the Redwood City area.","url":"http://ohana-api-test.herokuapp.com/api/locations/1","phones":[{"id":1,"location_id":1,"number":"650
-        780-7525"}],"contacts":[{"id":1,"location_id":1,"name":"Susan Houston","title":"Director
-        of Older Adult Services"},{"id":2,"location_id":1,"name":"Christina Gonzalez","title":"Center
-        Director"}],"id":"1","languages":["Filipino (Tagalog)","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:54.310-07:00","faxes":[{"id":1,"location_id":1,"number":"650
-        701-0856"}],"address":{"id":1,"location_id":1,"street":"2600 Middlefield Road","city":"Redwood
-        City","state":"CA","zip":"94063"},"description":"A walk-in center for older
-        adults that provides social services, wellness, recreational, educational
-        and creative activities including arts and crafts, computer classes and gardening
-        classes. Coffee and healthy breakfasts are available daily. A hot lunch is
-        served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
         case management (including in-home assessments) and bilingual information
         and referral about community services to persons age 60 or over on questions
         of housing, employment, household help, recreation and social activities,
@@ -208,9 +74,134 @@ http_interactions:
         groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
         Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
         Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
-        Agency of San Mateo County, Fair Oaks Intergenerational Center.","name":"Fair
-        Oaks Adult Activity Center","created_at":"2014-04-18T12:31:53.696-07:00","slug":"fair-oaks-adult-activity-center","longitude":-122.213221,"latitude":37.477227,"coordinates":[-122.213221,37.477227],"accessibility":["Ramp","Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849513696],"highlight":null,"_explanation":null}]'
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:26 GMT
+  recorded_at: Fri, 16 May 2014 07:48:12 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 16 May 2014 07:48:12 GMT
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=1&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=21&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="prev"
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
+      Status:
+      - 200 OK
+      X-Current-Page:
+      - '22'
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      X-Previous-Page:
+      - '21'
+      X-Request-Id:
+      - 006c32d8-b2b5-4de1-9ea2-0e77bc6818e4
+      X-Runtime:
+      - '0.041121'
+      X-Total-Count:
+      - '22'
+      X-Total-Pages:
+      - '22'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
+    http_version: 
+  recorded_at: Fri, 16 May 2014 07:48:12 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/when_there_are_no_results.yml
+++ b/spec/cassettes/results_page_pagination/when_there_are_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:20 GMT
+      - Fri, 16 May 2014 07:48:10 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 9a00d730-9b59-42c6-ac1e-bd4b395b67b3
+      - 43db576f-e6d3-4dcd-9df7-9264612d6ffc
       X-Runtime:
-      - '0.021909'
+      - '0.015367'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:20 GMT
+  recorded_at: Fri, 16 May 2014 07:48:10 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_result.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,31 +23,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:20 GMT
+      - Fri, 16 May 2014 07:48:15 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - d3d7b45c-c5a3-4114-9fc3-8b292c7c6417
+      - 1a7aba8f-c655-48f2-9b53-28bc3eff75e3
       X-Runtime:
-      - '0.028431'
+      - '0.042334'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Content-Length:
-      - '1771'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -59,13 +58,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -78,35 +78,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:20 GMT
+  recorded_at: Fri, 16 May 2014 07:48:15 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:53 GMT
+      - Fri, 16 May 2014 08:42:47 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - ec66b223-0e2b-49c6-8129-2d76316d9944
+      - 250e9aea-dc89-4fb1-8081-3747217760f5
       X-Runtime:
-      - '0.023087'
+      - '0.017593'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:53 GMT
+  recorded_at: Fri, 16 May 2014 08:42:47 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:54 GMT
+      - Fri, 16 May 2014 08:42:48 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,85 +89,65 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - b6c0167c-64b6-484a-b2cf-691190464966
+      - 0e0762c8-8835-4756-8f52-395f816d954a
       X-Runtime:
-      - '0.027661'
+      - '0.048093'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1747'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:54 GMT
+  recorded_at: Fri, 16 May 2014 08:42:48 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=3
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=3
     body:
       encoding: US-ASCII
       string: ''
@@ -180,8 +156,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -194,15 +168,15 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:54 GMT
+      - Fri, 16 May 2014 08:42:48 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=1>;
-        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2>;
-        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=4>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=1&per_page=1>;
+        rel="first", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1>;
+        rel="prev", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=4&per_page=1>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -210,31 +184,53 @@ http_interactions:
       X-Next-Page:
       - '4'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Previous-Page:
       - '2'
       X-Request-Id:
-      - 724aa5bc-d31b-41d4-a170-b448ea74ed07
+      - 2090f43f-249d-44ec-956a-45406bdea0f8
       X-Runtime:
-      - '0.030458'
+      - '0.049463'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '422'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"id":"20","organization":{"id":6,"name":"Location with no phone","slug":"location-with-no-phone","created_at":"2014-04-18T12:32:12.124-07:00","updated_at":"2014-04-18T12:32:12.475-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"updated_at":"2014-04-18T12:32:12.272-07:00","mail_address":{"id":20,"location_id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
-        phone","name":"Location with no phone","created_at":"2014-04-18T12:32:12.179-07:00","slug":"location-with-no-phone","short_desc":"no
-        phone","url":"http://ohana-api-test.herokuapp.com/api/locations/20","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849532179],"highlight":null,"_explanation":null}]'
+      string: '[{"id":3,"address":{"id":3,"street":"24 Second Avenue","city":"San
+        Mateo","state":"CA","zip":"94403"},"contacts":[{"id":4,"name":"Howard Lader,
+        LCSW","title":"Manager, Senior Peer Counseling"}],"coordinates":[-122.3263232,37.5639394],"description":"Offers
+        supportive counseling services to San Mateo County residents age 55 or over.
+        Volunteer counselors are selected and professionally trained to help their
+        peers face the challenges and concerns of growing older.  Training provides
+        topics that include understanding depression, cultural competence, sexuality,
+        community resources, and other subjects that are relevant to working with
+        older adults. After completion of training, weekly supervision groups are
+        provided for the volunteer senior peer counselors, as well as quarterly in-service
+        training seminars. Peer counseling services are provided in English, Spanish,
+        Chinese (Cantonese and Mandarin), Tagalog, and to the lesbian, gay, bisexual,
+        transgender older adult community. Formerly known as Family Service Agency
+        of San Mateo County, Senior Peer Counseling.","faxes":[{"id":3,"number":"650
+        403-4303"}],"hours":"Any time that is convenient for the client and peer counselor","languages":["Chinese
+        (Cantonese)","Chinese (Mandarin)","Filipino (Tagalog)","Spanish"],"mail_address":{"id":3,"attention":"PFS
+        Senior Peer Counseling","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94403"},"name":"Senior
+        Peer Counseling","phones":[{"id":3,"department":"English","number":"650 403-4300"}],"short_desc":"Offers
+        supportive counseling services to older persons.","slug":"senior-peer-counseling","transportation":"Service
+        is provided in person''s home or at a mutually agreed upon location.","updated_at":"2014-05-09T20:49:18.871-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/3","services":[{"id":3,"audience":"Older
+        adults age 55 or over who can benefit from counseling","eligibility":"Resident
+        of San Mateo County age 55 or over","fees":"None.","funding_sources":["County","Donations","Grants"],"keywords":["Geriatric
+        Counseling","Older Adults","Gay, Lesbian, Bisexual, Transgender Individuals"],"how_to_apply":"Phone
+        for information (403-4300 Ext. 4322).","service_areas":["San Mateo County"],"wait":"Varies.","updated_at":"2014-04-18T12:31:56.008-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:54 GMT
+  recorded_at: Fri, 16 May 2014 08:42:48 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=SanMaceo%20Example%20Agency.&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Peninsula%20Family%20Service&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -243,8 +239,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -257,88 +251,74 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:55 GMT
+      - Fri, 16 May 2014 08:42:49 GMT
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Peninsula+Family+Service&page=5&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Peninsula+Family+Service&page=2&per_page=1&utf8=%E2%9C%93>;
+        rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
+      X-Next-Page:
+      - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 1a5a613d-afea-42e3-9605-419f4eacaf05
+      - e75367f8-e02b-401a-9efc-b3eade116ed3
       X-Runtime:
-      - '0.024139'
+      - '0.067742'
       X-Total-Count:
-      - '1'
+      - '5'
       X-Total-Pages:
-      - '1'
+      - '5'
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:55 GMT
+  recorded_at: Fri, 16 May 2014 08:42:49 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_has_results.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:58 GMT
+      - Fri, 16 May 2014 08:43:34 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - ecab090b-be52-46d9-a54a-c455549499f5
+      - c73f6ebc-bb47-4623-8e7a-c5631909ef73
       X-Runtime:
-      - '0.034259'
+      - '0.020624'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:58 GMT
+  recorded_at: Fri, 16 May 2014 08:43:34 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Samaritan%20House&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:58 GMT
+      - Fri, 16 May 2014 08:43:34 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Samaritan+House&page=2&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Samaritan+House&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,11 +89,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - e394900a-2c4a-47e1-881f-e15c05cae11d
+      - e7bcd380-f197-4541-943a-b2ec6d8f4944
       X-Runtime:
-      - '0.026096'
+      - '0.076213'
       X-Total-Count:
       - '2'
       X-Total-Pages:
@@ -108,21 +104,24 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":19,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment
-        (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
-        City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:11.921-07:00"}],"mail_address":{"id":19,"location_id":19,"attention":"San
-        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
-        9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":19,"location_id":19,"number":"650
-        578-0400"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:11.939-07:00","faxes":[{"id":19,"location_id":19,"number":"650
-        578-0440"}],"address":{"id":19,"location_id":19,"street":"19 West 39th Avenue","city":"San
-        Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
-        dental care to those in need. Offers basic medical care for adults.","name":"San
-        Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849531266],"highlight":null,"_explanation":null}]'
+      string: '[{"id":18,"accessibility":["Disabled Restroom","Wheelchair"],"address":{"id":18,"street":"114
+        Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":26,"name":"Sharon
+        Petersen","title":"Administrator"}],"coordinates":[-122.207057,37.468678],"description":"Provides
+        free medical care to those in need. Offers basic medical exams for adults
+        and tuberculosis screening. Assists the individual to access other services
+        in the community. By appointment only, Project Smile provides a free dental
+        exam, dental cleaning and oral hygiene instruction for children, age 3-12,
+        of Samaritan House clients.","emails":["gracie@samaritanhouse.com"],"faxes":[{"id":18,"number":"650
+        839-1457"}],"hours":"Monday-Friday, 9-12, 2-5","languages":["Spanish"],"mail_address":{"id":18,"attention":"Redwood
+        City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"name":"Redwood
+        City Free Medical Clinic","phones":[{"id":18,"number":"650 839-1447"}],"short_desc":"Provides
+        free medical care to those in need.","slug":"redwood-city-free-medical-clinic","transportation":"SAMTRANS
+        stops within 2 blocks.","updated_at":"2014-05-09T20:49:18.967-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/18","services":[{"id":18,"eligibility":"Low-income
+        person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
+        SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
+        screening appointment. Medical visits are by appointment only.","service_areas":["Atherton","East
+        Palo Alto","Menlo Park","Redwood City","San Carlos"],"wait":"Varies.","updated_at":"2014-04-18T12:32:10.649-07:00"}],"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:58 GMT
+  recorded_at: Fri, 16 May 2014 08:43:34 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_no_results.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_custom_value_and_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:10 GMT
+      - Fri, 16 May 2014 08:43:29 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 10909814-262f-4c11-b3da-bdc867dc72eb
+      - 794eab7a-c76e-4313-b37b-d028c7138a71
       X-Runtime:
-      - '0.057238'
+      - '0.016790'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:10 GMT
+  recorded_at: Fri, 16 May 2014 08:43:29 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=United%20States%20Government&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&org_name=United%20States%20Government&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,22 +75,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:11 GMT
+      - Fri, 16 May 2014 08:43:29 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=United+States+Government&page=0&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&org_name=United+States+Government&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - fb156160-84dd-44dc-963c-a17f9bdbeaf8
+      - 02abd2ea-35ca-4e7f-88d5-f32783d17d5f
       X-Runtime:
-      - '0.021639'
+      - '0.026850'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +103,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:11 GMT
+  recorded_at: Fri, 16 May 2014 08:43:29 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_custom_value_is_added.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_custom_value_is_added.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:20 GMT
+      - Fri, 16 May 2014 08:43:23 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - db18bee4-37c8-41c3-8a71-13eafdaefcbf
+      - 95b871f7-1772-4080-b029-ae3e7bcbd2b6
       X-Runtime:
-      - '0.044849'
+      - '0.017139'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:20 GMT
+  recorded_at: Fri, 16 May 2014 08:43:23 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&org_name=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,22 +75,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:20 GMT
+      - Fri, 16 May 2014 08:43:24 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&org_name=Custom+Value&page=0&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&org_name=Custom+Value&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 6ade7502-8791-4435-80fc-7e2ffd1d8326
+      - 3239c308-9e1c-4e3a-aebb-9d09444d29df
       X-Runtime:
-      - '0.050316'
+      - '0.018572'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +103,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:21 GMT
+  recorded_at: Fri, 16 May 2014 08:43:24 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:09 GMT
+      - Fri, 16 May 2014 08:42:39 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - bf15569b-843a-47a7-b90b-315c5e21eddb
+      - b5e4060e-25ba-4339-9cd3-b9bed3ffcc0f
       X-Runtime:
-      - '0.052546'
+      - '0.023784'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:09 GMT
+  recorded_at: Fri, 16 May 2014 08:42:39 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_agency_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:00 GMT
+      - Fri, 16 May 2014 08:43:31 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 18f7c1b6-1b48-4566-b16c-4889d8a71ba9
+      - 598a6390-ab43-4377-aded-cd030f2ee1c7
       X-Runtime:
-      - '0.029986'
+      - '0.064926'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:00 GMT
+  recorded_at: Fri, 16 May 2014 08:43:31 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_clicking_organization_link_in_results.yml
+++ b/spec/cassettes/results_page_search/when_clicking_organization_link_in_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:17 GMT
+      - Fri, 16 May 2014 08:43:21 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 1a25f704-b14f-4ac7-871b-cadfbd9442cf
+      - b0f17cc4-8b5a-4e11-95fe-8731d3d8475a
       X-Runtime:
-      - '0.038631'
+      - '0.016154'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:17 GMT
+  recorded_at: Fri, 16 May 2014 08:43:21 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan%20House&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Samaritan%20House&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:18 GMT
+      - Fri, 16 May 2014 08:43:22 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=6&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=Samaritan+House&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Samaritan+House&page=2&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=Samaritan+House&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,45 +89,44 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 36a278ea-9200-4aaf-9c81-293926966d67
+      - b5e89d20-e4d0-4249-ae08-f0f282e828aa
       X-Runtime:
-      - '0.021803'
+      - '0.039763'
       X-Total-Count:
-      - '6'
+      - '2'
       X-Total-Pages:
-      - '6'
+      - '2'
       Content-Length:
-      - '1130'
+      - '996'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":18,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment.
-        Medical visits are by appointment only.","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Atherton","East
-        Palo Alto","Menlo Park","Redwood City","San Carlos"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:10.649-07:00"}],"mail_address":{"id":18,"location_id":18,"attention":"Redwood
-        City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"hours":"Monday-Friday,
-        9-12, 2-5","urls":["http://www.samaritanhouse.com"],"emails":["gracie@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 2 blocks.","short_desc":"Provides free medical care to those
-        in need.","url":"http://ohana-api-test.herokuapp.com/api/locations/18","phones":[{"id":18,"location_id":18,"number":"650
-        839-1447"}],"contacts":[{"id":26,"location_id":18,"name":"Sharon Petersen","title":"Administrator"}],"id":"18","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:10.666-07:00","faxes":[{"id":18,"location_id":18,"number":"650
-        839-1457"}],"address":{"id":18,"location_id":18,"street":"114 Fifth Avenue","city":"Redwood
-        City","state":"CA","zip":"94063"},"description":"Provides free medical care
-        to those in need. Offers basic medical exams for adults and tuberculosis screening.
-        Assists the individual to access other services in the community. By appointment
-        only, Project Smile provides a free dental exam, dental cleaning and oral
-        hygiene instruction for children, age 3-12, of Samaritan House clients.","name":"Redwood
-        City Free Medical Clinic","created_at":"2014-04-18T12:32:09.882-07:00","slug":"redwood-city-free-medical-clinic","longitude":-122.207057,"latitude":37.468678,"coordinates":[-122.207057,37.468678],"accessibility":["Disabled
-        Restroom","Wheelchair"],"_score":0.04292514,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+      string: '[{"id":18,"accessibility":["Disabled Restroom","Wheelchair"],"address":{"id":18,"street":"114
+        Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":26,"name":"Sharon
+        Petersen","title":"Administrator"}],"coordinates":[-122.207057,37.468678],"description":"Provides
+        free medical care to those in need. Offers basic medical exams for adults
+        and tuberculosis screening. Assists the individual to access other services
+        in the community. By appointment only, Project Smile provides a free dental
+        exam, dental cleaning and oral hygiene instruction for children, age 3-12,
+        of Samaritan House clients.","emails":["gracie@samaritanhouse.com"],"faxes":[{"id":18,"number":"650
+        839-1457"}],"hours":"Monday-Friday, 9-12, 2-5","languages":["Spanish"],"mail_address":{"id":18,"attention":"Redwood
+        City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"name":"Redwood
+        City Free Medical Clinic","phones":[{"id":18,"number":"650 839-1447"}],"short_desc":"Provides
+        free medical care to those in need.","slug":"redwood-city-free-medical-clinic","transportation":"SAMTRANS
+        stops within 2 blocks.","updated_at":"2014-05-09T20:49:18.967-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/18","services":[{"id":18,"eligibility":"Low-income
+        person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
+        SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
+        screening appointment. Medical visits are by appointment only.","service_areas":["Atherton","East
+        Palo Alto","Menlo Park","Redwood City","San Carlos"],"wait":"Varies.","updated_at":"2014-04-18T12:32:10.649-07:00"}],"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:18 GMT
+  recorded_at: Fri, 16 May 2014 08:43:22 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan%20House
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Samaritan%20House
     body:
       encoding: US-ASCII
       string: ''
@@ -140,8 +135,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -154,13 +147,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:19 GMT
+      - Fri, 16 May 2014 08:43:23 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Samaritan+House&page=2>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Samaritan+House&page=2&per_page=1>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Samaritan+House&page=2&per_page=1>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -168,36 +161,39 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - fdb08656-d599-459a-96d7-51556ca10543
+      - 690315ac-65a4-471b-9cf7-f8d1190c3901
       X-Runtime:
-      - '0.019792'
+      - '0.066880'
       X-Total-Count:
       - '2'
       X-Total-Pages:
       - '2'
-      Content-Length:
-      - '1015'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":19,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment
-        (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
-        City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:11.921-07:00"}],"mail_address":{"id":19,"location_id":19,"attention":"San
-        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
-        9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":19,"location_id":19,"number":"650
-        578-0400"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:11.939-07:00","faxes":[{"id":19,"location_id":19,"number":"650
-        578-0440"}],"address":{"id":19,"location_id":19,"street":"19 West 39th Avenue","city":"San
-        Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
-        dental care to those in need. Offers basic medical care for adults.","name":"San
-        Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849531266],"highlight":null,"_explanation":null}]'
+      string: '[{"id":18,"accessibility":["Disabled Restroom","Wheelchair"],"address":{"id":18,"street":"114
+        Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":26,"name":"Sharon
+        Petersen","title":"Administrator"}],"coordinates":[-122.207057,37.468678],"description":"Provides
+        free medical care to those in need. Offers basic medical exams for adults
+        and tuberculosis screening. Assists the individual to access other services
+        in the community. By appointment only, Project Smile provides a free dental
+        exam, dental cleaning and oral hygiene instruction for children, age 3-12,
+        of Samaritan House clients.","emails":["gracie@samaritanhouse.com"],"faxes":[{"id":18,"number":"650
+        839-1457"}],"hours":"Monday-Friday, 9-12, 2-5","languages":["Spanish"],"mail_address":{"id":18,"attention":"Redwood
+        City Free Medical Clinic","street":"114 Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"name":"Redwood
+        City Free Medical Clinic","phones":[{"id":18,"number":"650 839-1447"}],"short_desc":"Provides
+        free medical care to those in need.","slug":"redwood-city-free-medical-clinic","transportation":"SAMTRANS
+        stops within 2 blocks.","updated_at":"2014-05-09T20:49:18.967-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/18","services":[{"id":18,"eligibility":"Low-income
+        person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
+        SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
+        screening appointment. Medical visits are by appointment only.","service_areas":["Atherton","East
+        Palo Alto","Menlo Park","Redwood City","San Carlos"],"wait":"Varies.","updated_at":"2014-04-18T12:32:10.649-07:00"}],"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:19 GMT
+  recorded_at: Fri, 16 May 2014 08:43:23 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_clicking_the_reset_button.yml
+++ b/spec/cassettes/results_page_search/when_clicking_the_reset_button.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:01 GMT
+      - Fri, 16 May 2014 08:42:46 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - be7aa6eb-1a2b-4f31-853d-d6f9cfe9aedd
+      - d61ae981-c505-4bfd-999a-6e631021e6b3
       X-Runtime:
-      - '0.019374'
+      - '0.018641'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:01 GMT
+  recorded_at: Fri, 16 May 2014 08:42:46 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:02 GMT
+      - Fri, 16 May 2014 08:42:47 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,80 +89,60 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 2907392b-7c63-4219-ad2d-dc45ebdc349a
+      - 52f51b51-97b3-4b99-8f61-114d98947e86
       X-Runtime:
-      - '0.102936'
+      - '0.045753'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1747'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:02 GMT
+  recorded_at: Fri, 16 May 2014 08:42:47 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:14 GMT
+      - Fri, 16 May 2014 08:42:40 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - d673de3d-9764-45db-96af-568beb6f3745
+      - b5fbdb5c-7280-422d-9063-45a6040f0088
       X-Runtime:
-      - '0.042497'
+      - '0.015195'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:14 GMT
+  recorded_at: Fri, 16 May 2014 08:42:40 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:15 GMT
+      - Fri, 16 May 2014 08:42:40 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,85 +89,65 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 0559ef1d-2c51-4aa9-a431-f50d3c2e1886
+      - 80a13ac1-1e74-49a5-9b86-9ba33b1bf141
       X-Runtime:
-      - '0.023465'
+      - '0.039896'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1747'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:15 GMT
+  recorded_at: Fri, 16 May 2014 08:42:41 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=fairfax,%20va&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=fairfax,%20va&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -180,8 +156,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -194,22 +168,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:16 GMT
+      - Fri, 16 May 2014 08:42:41 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=fairfax%2C+va&page=0&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=fairfax%2C+va&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 63698dab-0848-45f2-babd-5b934d3f8a47
+      - 87bb60db-c013-4c92-a65b-5f626b50c768
       X-Runtime:
-      - '0.020441'
+      - '0.046362'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -222,5 +196,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:16 GMT
+  recorded_at: Fri, 16 May 2014 08:42:41 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_has_results.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_has_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:22 GMT
+      - Fri, 16 May 2014 08:43:20 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - ee404d99-1b3d-4ee7-b303-8abf8444d02a
+      - 785dcdae-9376-444a-8c18-607690a7dfa5
       X-Runtime:
-      - '0.250533'
+      - '0.017181'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:22 GMT
+  recorded_at: Fri, 16 May 2014 08:43:20 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San%20Mateo,%20CA&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=San%20Mateo,%20CA&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:23 GMT
+      - Fri, 16 May 2014 08:43:20 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=6&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=San+Mateo%2C+CA&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=San+Mateo%2C+CA&page=6&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=San+Mateo%2C+CA&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,11 +89,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 7b2b341b-0889-43fb-bf16-d9eb85d08a4e
+      - a0aa05e6-cc60-46dd-adfd-bbfd78b39c29
       X-Runtime:
-      - '0.039545'
+      - '0.060968'
       X-Total-Count:
       - '6'
       X-Total-Pages:
@@ -108,36 +104,35 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":2,"audience":"Residents of San Mateo County age
-        55 or over","eligibility":"Age 55 or over, county resident and willing and
-        able to work. Income requirements vary according to program","fees":"None.
-        Donations requested of clients who can afford it.","how_to_apply":"Apply by
-        phone for an appointment.","wait":"Varies.","funding_sources":["County","Federal","State"],"service_areas":["San
-        Mateo County"],"keywords":["EMPLOYMENT/TRAINING SERVICES","Job Development","Job
-        Information/Placement/Referral","Job Training","Job Training Formats","Job
-        Search/Placement","Older Adults"],"updated_at":"2014-04-18T12:31:55.106-07:00"}],"mail_address":{"id":2,"location_id":2,"attention":"PFS
-        Second Career Services","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"hours":"Monday-Friday,
-        9-5","urls":["http://www.peninsulafamilyservice.org"],"emails":["bbrown@peninsulafamilyservice.org"],"transportation":"SAMTRANS
-        stops within 1 block, CALTRAIN stops within 6 blocks.","short_desc":"Provides
-        training and job placement to eligible persons age 55 or over. All persons
-        age 55 or over have access to information in the program''s job bank.","url":"http://ohana-api-test.herokuapp.com/api/locations/2","phones":[{"id":2,"location_id":2,"number":"650
-        403-4300","extension":"Ext. 4385"}],"contacts":[{"id":3,"location_id":2,"name":"Brenda
-        Brown","title":"Director, Second Career Services"}],"id":"2","languages":["Chinese
-        (Mandarin)","Filipino (Tagalog)","Italian","Spanish"],"organization":{"id":1,"name":"Peninsula
-        Family Service","slug":"peninsula-family-service","created_at":"2014-04-18T12:31:52.935-07:00","updated_at":"2014-04-18T12:31:57.779-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"},"updated_at":"2014-04-18T12:31:55.120-07:00","faxes":[{"id":2,"location_id":2,"number":"650
-        403-4302"}],"address":{"id":2,"location_id":2,"street":"24 Second Avenue","city":"San
-        Mateo","state":"CA","zip":"94401"},"description":"Provides training and job
-        placement to eligible people age 55 or over who meet certain income qualifications.
-        An income of 125% of poverty level or less is required for subsidized employment
-        and training. (No income requirements for job matchup program.) If a person
-        seems likely to be qualified after a preliminary phone call or visit, he or
-        she must complete an application at this office. Staff will locate appropriate
-        placements for applicants, provide orientation and on-the-job training and
-        assist with finding a job outside the program. Any county resident, regardless
-        of income, age 55 or over has access to the program, job developers and the
-        job bank. Also provides referrals to classroom training. Formerly known as
-        Family Service Agency of San Mateo County, Senior Employment Services.","name":"Second
-        Career Employment Program","created_at":"2014-04-18T12:31:54.689-07:00","slug":"second-career-employment-program","longitude":-122.3263232,"latitude":37.5639394,"coordinates":[-122.3263232,37.5639394],"accessibility":["Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.07871992834851854],"highlight":null,"_explanation":null}]'
+      string: '[{"id":2,"accessibility":["Wheelchair"],"address":{"id":2,"street":"24
+        Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"contacts":[{"id":3,"name":"Brenda
+        Brown","title":"Director, Second Career Services"}],"coordinates":[-122.3263232,37.5639394],"description":"Provides
+        training and job placement to eligible people age 55 or over who meet certain
+        income qualifications. An income of 125% of poverty level or less is required
+        for subsidized employment and training. (No income requirements for job matchup
+        program.) If a person seems likely to be qualified after a preliminary phone
+        call or visit, he or she must complete an application at this office. Staff
+        will locate appropriate placements for applicants, provide orientation and
+        on-the-job training and assist with finding a job outside the program. Any
+        county resident, regardless of income, age 55 or over has access to the program,
+        job developers and the job bank. Also provides referrals to classroom training.
+        Formerly known as Family Service Agency of San Mateo County, Senior Employment
+        Services.","emails":["bbrown@peninsulafamilyservice.org"],"faxes":[{"id":2,"number":"650
+        403-4302"}],"hours":"Monday-Friday, 9-5","languages":["Chinese (Mandarin)","Filipino
+        (Tagalog)","Italian","Spanish"],"mail_address":{"id":2,"attention":"PFS Second
+        Career Services","street":"24 Second Avenue","city":"San Mateo","state":"CA","zip":"94401"},"name":"Second
+        Career Employment Program","phones":[{"id":2,"extension":"Ext. 4385","number":"650
+        403-4300"}],"short_desc":"Provides training and job placement to eligible
+        persons age 55 or over. All persons age 55 or over have access to information
+        in the program''s job bank.","slug":"second-career-employment-program","transportation":"SAMTRANS
+        stops within 1 block, CALTRAIN stops within 6 blocks.","updated_at":"2014-05-09T20:49:18.857-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/2","services":[{"id":2,"audience":"Residents
+        of San Mateo County age 55 or over","eligibility":"Age 55 or over, county
+        resident and willing and able to work. Income requirements vary according
+        to program","fees":"None. Donations requested of clients who can afford it.","funding_sources":["County","Federal","State"],"keywords":["EMPLOYMENT/TRAINING
+        SERVICES","Job Development","Job Information/Placement/Referral","Job Training","Job
+        Training Formats","Job Search/Placement","Older Adults"],"how_to_apply":"Apply
+        by phone for an appointment.","service_areas":["San Mateo County"],"wait":"Varies.","updated_at":"2014-04-18T12:31:55.106-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:23 GMT
+  recorded_at: Fri, 16 May 2014 08:43:21 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_no_results.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_custom_value_and_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:12 GMT
+      - Fri, 16 May 2014 08:42:44 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 7b38d34b-f804-46ad-8835-3ae03422d0be
+      - f5020856-feb1-4052-969f-7775d00bfb10
       X-Runtime:
-      - '0.018727'
+      - '0.020867'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:12 GMT
+  recorded_at: Fri, 16 May 2014 08:42:44 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=San%20Mateo,%20CA&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=San%20Mateo,%20CA&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,22 +75,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:13 GMT
+      - Fri, 16 May 2014 08:42:44 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=San+Mateo%2C+CA&page=0&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=San+Mateo%2C+CA&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 7ccc0719-01b8-4a7c-a542-398e7b2963c4
+      - 779c93be-8aa1-4d20-bec0-e96a46765dd4
       X-Runtime:
-      - '0.022262'
+      - '0.026000'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +103,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:13 GMT
+  recorded_at: Fri, 16 May 2014 08:42:44 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_custom_value_is_added.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_custom_value_is_added.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:03 GMT
+      - Fri, 16 May 2014 08:43:27 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - c8d43187-cf40-4734-97f1-3c1aaa1b7234
+      - 0c448337-b7b8-4d8a-bd30-278835b8e705
       X-Runtime:
-      - '0.023333'
+      - '0.016954'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:03 GMT
+  recorded_at: Fri, 16 May 2014 08:43:27 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=Custom%20Value&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,53 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:24:04 GMT
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 400 Bad Request
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Request-Id:
-      - ce4863f3-6989-4c1c-aa89-e51eed13df41
-      X-Runtime:
-      - '0.053704'
-      Content-Length:
-      - '68'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:04 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -124,22 +75,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:04 GMT
+      - Fri, 16 May 2014 08:43:27 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg&page=0>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=Custom+Value&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 3e4630cc-e3b8-4bef-a39f-21957f16c28a
+      - 8ff85ae3-70f8-4944-a92c-2cec1531c4fc
       X-Runtime:
-      - '0.023989'
+      - '0.026152'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -152,5 +103,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:04 GMT
+  recorded_at: Fri, 16 May 2014 08:43:28 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:24 GMT
+      - Fri, 16 May 2014 08:42:45 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4ca9df8f-6916-47d4-90e8-82c0dd45d452
+      - f812667b-f015-4a3b-b2fc-f8d099eb55d7
       X-Runtime:
-      - '0.035306'
+      - '0.015734'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:24 GMT
+  recorded_at: Fri, 16 May 2014 08:42:45 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_location_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:08 GMT
+      - Fri, 16 May 2014 08:43:32 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - faa4f3c7-7cd6-4f72-8f5e-189aebeb9228
+      - 0e635198-3350-480e-a9d0-642b1b1a5bf2
       X-Runtime:
-      - '0.056186'
+      - '0.016408'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:08 GMT
+  recorded_at: Fri, 16 May 2014 08:43:32 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_cached_values_and_new_option_is_selected.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_cached_values_and_new_option_is_selected.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:50 GMT
+      - Fri, 16 May 2014 08:42:42 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 962f9ce7-4df6-4a1c-829c-a8b6782e18be
+      - be527128-9683-45d9-9916-e88f580e521b
       X-Runtime:
-      - '0.024644'
+      - '0.015224'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:50 GMT
+  recorded_at: Fri, 16 May 2014 08:42:42 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,13 +75,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:51 GMT
+      - Fri, 16 May 2014 08:42:42 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -93,11 +89,104 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 72086ac0-00f5-4546-be1a-1d7f7014f4fa
+      - 97d20ab9-4d6f-4d8e-b3a4-4e07e307d2b3
       X-Runtime:
-      - '0.022725'
+      - '0.048300'
+      X-Total-Count:
+      - '22'
+      X-Total-Pages:
+      - '22'
+      Content-Length:
+      - '1813'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
+    http_version: 
+  recorded_at: Fri, 16 May 2014 08:42:43 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&utf8=%E2%9C%93
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 16 May 2014 08:42:43 GMT
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1&utf8=%E2%9C%93>;
+        rel="next"
+      Server:
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
+      Status:
+      - 200 OK
+      X-Current-Page:
+      - '1'
+      X-Next-Page:
+      - '2'
+      X-Powered-By:
+      - Phusion Passenger 4.0.41
+      X-Request-Id:
+      - e4fe2d8b-6882-4147-ac22-0296431aa0a7
+      X-Runtime:
+      - '0.052287'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -108,180 +197,45 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:51 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&utf8=%E2%9C%93
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:23:51 GMT
-      Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2&utf8=%E2%9C%93>;
-        rel="next"
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 200 OK
-      X-Current-Page:
-      - '1'
-      X-Next-Page:
-      - '2'
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Request-Id:
-      - 3568b96d-eb63-4a88-b00d-f8677659c07d
-      X-Runtime:
-      - '0.021693'
-      X-Total-Count:
-      - '22'
-      X-Total-Pages:
-      - '22'
-      Content-Length:
-      - '1753'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:51 GMT
+  recorded_at: Fri, 16 May 2014 08:42:43 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_legend_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_legend_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:23:57 GMT
+      - Fri, 16 May 2014 08:43:32 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 155d39fc-4378-4b60-8668-a69966469afa
+      - 2d035531-aaf1-4b2f-b63c-0a1744180b4a
       X-Runtime:
-      - '0.050440'
+      - '0.028039'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,5 +51,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:23:57 GMT
+  recorded_at: Fri, 16 May 2014 08:43:32 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_toggle_is_toggled.yml
+++ b/spec/cassettes/results_page_search/when_service-area_filter_has_no_cached_values_and_toggle_is_toggled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,22 +23,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:05 GMT
+      - Fri, 16 May 2014 08:43:25 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&page=0&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&page=0&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - fcbf1204-b537-4b8c-a63d-38f522a099e4
+      - d0357973-fe8d-4af1-930c-a4b757e10374
       X-Runtime:
-      - '0.024240'
+      - '0.017476'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -53,10 +51,10 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:05 GMT
+  recorded_at: Fri, 16 May 2014 08:43:25 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&service_area=smc&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&service_area=smc&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -65,8 +63,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -79,22 +75,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:06 GMT
+      - Fri, 16 May 2014 08:43:26 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&page=0&service_area=smc&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&page=0&per_page=1&service_area=smc&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 3ed8868e-71de-485b-9c15-49538111d340
+      - 0754b9a5-0214-4895-84dd-2a06a0101442
       X-Runtime:
-      - '0.034282'
+      - '0.018559'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -107,5 +103,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:06 GMT
+  recorded_at: Fri, 16 May 2014 08:43:26 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:36 GMT
+      - Fri, 16 May 2014 08:53:16 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 520be674-2bc6-4014-bac5-3cb3bb5d9d68
+      - 17de160d-55b3-487a-8141-8bc983fdca1c
       X-Runtime:
-      - '0.041338'
+      - '0.045895'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,70 +52,50 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:36 GMT
+  recorded_at: Fri, 16 May 2014 08:53:16 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=sdaff&location=94403&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=sdaff&location=94403&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,22 +116,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:38 GMT
+      - Fri, 16 May 2014 08:53:16 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=sdaff&location=94403&page=0&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=sdaff&location=94403&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4c6a3cbb-e90e-4aac-a2d8-3568716e90a2
+      - ae7f488f-5412-4917-bac0-ae03b42c9d9f
       X-Runtime:
-      - '0.024362'
+      - '0.054615'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -168,5 +144,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:38 GMT
+  recorded_at: Fri, 16 May 2014 08:53:16 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_and_location_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:34 GMT
+      - Fri, 16 May 2014 08:53:19 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4e122db6-306c-4803-a247-ccb59fbe7142
+      - 94341db9-1532-49a5-8f96-c12bfbee9752
       X-Runtime:
-      - '0.020925'
+      - '0.083017'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,70 +52,50 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:34 GMT
+  recorded_at: Fri, 16 May 2014 08:53:19 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=clinic&location=94403&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=clinic&location=94403&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,19 +116,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:35 GMT
+      - Fri, 16 May 2014 08:53:19 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - c495143d-d041-4a0e-89ad-c26080d0cd2a
+      - 81a0a032-9edd-4823-8fb9-f8fd967efb2a
       X-Runtime:
-      - '0.023464'
+      - '0.058025'
       X-Total-Count:
       - '1'
       X-Total-Pages:
@@ -163,21 +139,22 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":19,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment
-        (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
-        City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:11.921-07:00"}],"mail_address":{"id":19,"location_id":19,"attention":"San
-        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
-        9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":19,"location_id":19,"number":"650
-        578-0400"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:11.939-07:00","faxes":[{"id":19,"location_id":19,"number":"650
-        578-0440"}],"address":{"id":19,"location_id":19,"street":"19 West 39th Avenue","city":"San
-        Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
-        dental care to those in need. Offers basic medical care for adults.","name":"San
-        Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.6741946265175476],"highlight":null,"_explanation":null}]'
+      string: '[{"id":19,"accessibility":["Elevator","Ramp","Wheelchair"],"address":{"id":19,"street":"19
+        West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"contacts":[{"id":27,"name":"Sharon
+        Petersen","title":"Administrator"}],"coordinates":[-122.2931236,37.5326941],"description":"Provides
+        free medical and dental care to those in need. Offers basic medical care for
+        adults.","emails":["smcmed@samaritanhouse.com"],"faxes":[{"id":19,"number":"650
+        578-0440"}],"hours":"Monday-Friday, 9-12, 1-4","languages":["Spanish"],"mail_address":{"id":19,"attention":"San
+        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"name":"San
+        Mateo Free Medical Clinic","phones":[{"id":19,"number":"650 578-0400"}],"short_desc":"Provides
+        free medical and dental care to those in need. Offers basic medical care for
+        adults.","slug":"san-mateo-free-medical-clinic","transportation":"SAMTRANS
+        stops within 1 block.","updated_at":"2014-05-09T21:37:14.734-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/19","services":[{"id":19,"eligibility":"Low-income
+        person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
+        SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
+        screening appointment (650-347-3648).","service_areas":["Belmont","Burlingame","Foster
+        City","Millbrae","San Carlos","San Mateo"],"wait":"Varies.","updated_at":"2014-04-18T12:32:11.921-07:00"}],"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:35 GMT
+  recorded_at: Fri, 16 May 2014 08:53:20 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:50 GMT
+      - Fri, 16 May 2014 08:53:17 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,85 +37,65 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 997fc494-d949-476a-8d0f-ab8df8067b2b
+      - c81199e6-08b7-4ed2-89a7-800d1c801e95
       X-Runtime:
-      - '0.020181'
+      - '0.057916'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1753'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:50 GMT
+  recorded_at: Fri, 16 May 2014 08:53:17 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location=&location-option=&location-option-input=&org-name-option=&org-name-option-input=&org_name=&service-area-option=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,22 +116,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:51 GMT
+      - Fri, 16 May 2014 08:53:17 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=asdfg&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=0&service-area-option=&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=asdfg&location-option-input=&location-option=&location=&org-name-option-input=&org-name-option=&org_name=&page=0&per_page=1&service-area-option=&service_area=&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 18d9ad82-9054-40e6-b9e2-45bdd03475b3
+      - ac2c77c3-9b61-4fd2-8324-ada860bd7cf9
       X-Runtime:
-      - '0.021090'
+      - '0.018479'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -168,5 +144,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:51 GMT
+  recorded_at: Fri, 16 May 2014 08:53:17 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_keyword_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_keyword_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:47 GMT
+      - Fri, 16 May 2014 08:53:23 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,85 +37,65 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 34185e6c-fdf9-4993-9725-4a692dc9b52f
+      - 73f98515-b3f5-4ee4-a7c2-c42ed1b41245
       X-Runtime:
-      - '0.024758'
+      - '0.047277'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1753'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:47 GMT
+  recorded_at: Fri, 16 May 2014 08:53:24 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=maceo
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=maceo
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,31 +116,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:48 GMT
+      - Fri, 16 May 2014 08:53:24 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 123129fd-57ce-40bc-823f-49dc2d25a560
+      - d405d9ad-094b-4a07-a73c-543a2089c981
       X-Runtime:
-      - '0.022870'
+      - '0.049936'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
-      Content-Length:
-      - '1749'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
+      string: '[{"id":22,"accessibility":["Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"id":29,"name":"Suzanne
+        Badenhoop","title":"Board President"}],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
         THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
         APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
         metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
@@ -174,13 +151,14 @@ http_interactions:
         nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
         tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
         Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"faxes":[{"id":21,"number":"650
+        627-8244"}],"hours":"Monday-Friday, 8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese
+        (Cantonese)","Chinese (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"mail_address":{"id":21,"attention":"Hella
+        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"name":"San
+        Maceo Agency","phones":[{"id":21,"department":"Information","number":"650
+        372-6200"},{"id":22,"department":"Reservations","number":"650 372-6200"}],"short_desc":"[NOTE
+        THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-05-09T20:49:19.003-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/22","services":[{"id":22,"audience":"Profit
         and nonprofit businesses, the public, military facilities, schools and government
         entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
         TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
@@ -193,35 +171,31 @@ http_interactions:
         nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
         orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
         egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":0.009998767,"_type":"location","_index":"production-ohana_api","_version":null,"sort":null,"highlight":null,"_explanation":null}]'
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"bazfoo","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00"},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"keywords":["Ruby
+        on Rails/MongoDB/Redis","FIFA World Cup"],"how_to_apply":"Walk in or apply
+        by phone or mail","name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00"}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:48 GMT
+  recorded_at: Fri, 16 May 2014 08:53:24 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_location_that_returns_no_results.yml
+++ b/spec/cassettes/results_page_search/with_location_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:28 GMT
+      - Fri, 16 May 2014 08:53:20 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - bb379da1-c8d2-4be0-9349-7df0f6bb9ef7
+      - d43ffb26-0264-433f-863b-deb013f833fc
       X-Runtime:
-      - '0.028949'
+      - '0.053222'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,70 +52,50 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:28 GMT
+  recorded_at: Fri, 16 May 2014 08:53:20 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=asdfg&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=asdfg&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,53 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 09 May 2014 22:24:30 GMT
-      Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
-      Status:
-      - 400 Bad Request
-      X-Powered-By:
-      - Phusion Passenger 4.0.40
-      X-Request-Id:
-      - 7c3b24c3-5ebe-4d6d-82e0-e6c8b9e8409b
-      X-Runtime:
-      - '0.075565'
-      Content-Length:
-      - '68'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"error":"bad request","description":"Invalid ZIP code or address."}'
-    http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:30 GMT
-- request:
-    method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/vnd.ohanapi-v1+json
-      User-Agent:
-      - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -185,22 +116,22 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:30 GMT
+      - Fri, 16 May 2014 08:53:21 GMT
       Etag:
       - '"d751713988987e9331980363e24189ce"'
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?api_token=<API_TOKEN>&keyword=asdfasg&page=0>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=asdfg&page=0&per_page=1&utf8=%E2%9C%93>;
         rel="last"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 4bac9584-ea95-4a82-bfe2-228b572088df
+      - e1a6642c-3c66-44e3-8f98-cca9f81c0112
       X-Runtime:
-      - '0.040734'
+      - '0.038617'
       X-Total-Count:
       - '0'
       X-Total-Pages:
@@ -213,5 +144,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:30 GMT
+  recorded_at: Fri, 16 May 2014 08:53:21 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/results_page_search/with_location_that_returns_results.yml
+++ b/spec/cassettes/results_page_search/with_location_that_returns_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&service_area=&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:31 GMT
+      - Fri, 16 May 2014 08:53:22 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=22&service_area=&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&keyword=&location=&page=2&service_area=&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=22&per_page=1&service_area=&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&keyword=&location=&page=2&per_page=1&service_area=&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,11 +37,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - e5c82ef8-b3a0-4dd6-b760-341767f24801
+      - 60e2865e-5dc7-420a-868d-9d7cc2937c04
       X-Runtime:
-      - '0.054254'
+      - '0.039163'
       X-Total-Count:
       - '22'
       X-Total-Pages:
@@ -54,70 +52,50 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:31 GMT
+  recorded_at: Fri, 16 May 2014 08:53:22 GMT
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&utf8=%E2%9C%93
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=94403&utf8=%E2%9C%93
     body:
       encoding: US-ASCII
       string: ''
@@ -126,8 +104,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -140,13 +116,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:32 GMT
+      - Fri, 16 May 2014 08:53:23 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=6&utf8=%E2%9C%93>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&location=94403&page=2&utf8=%E2%9C%93>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=94403&page=6&per_page=1&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&location=94403&page=2&per_page=1&utf8=%E2%9C%93>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -154,11 +130,11 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - e3b1b6fb-53ec-4c94-90f1-aa48aeb87686
+      - 261f6703-3259-4b69-94d6-0dc675a3f8f6
       X-Runtime:
-      - '0.032721'
+      - '0.047764'
       X-Total-Count:
       - '6'
       X-Total-Pages:
@@ -169,21 +145,22 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":19,"eligibility":"Low-income person without access
-        to health care","fees":"None.","how_to_apply":"Call for screening appointment
-        (650-347-3648).","wait":"Varies.","funding_sources":["Donations","Grants"],"service_areas":["Belmont","Burlingame","Foster
-        City","Millbrae","San Carlos","San Mateo"],"keywords":["HEALTH SERVICES","Outpatient
-        Care","Community Clinics"],"updated_at":"2014-04-18T12:32:11.921-07:00"}],"mail_address":{"id":19,"location_id":19,"attention":"San
-        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"hours":"Monday-Friday,
-        9-12, 1-4","urls":["http://www.samaritanhouse.com"],"emails":["smcmed@samaritanhouse.com"],"transportation":"SAMTRANS
-        stops within 1 block.","short_desc":"Provides free medical and dental care
-        to those in need. Offers basic medical care for adults.","url":"http://ohana-api-test.herokuapp.com/api/locations/19","phones":[{"id":19,"location_id":19,"number":"650
-        578-0400"}],"contacts":[{"id":27,"location_id":19,"name":"Sharon Petersen","title":"Administrator"}],"id":"19","languages":["Spanish"],"organization":{"id":5,"name":"Samaritan
-        House","slug":"samaritan-house","created_at":"2014-04-18T12:32:09.605-07:00","updated_at":"2014-04-18T12:32:12.060-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"},"updated_at":"2014-04-18T12:32:11.939-07:00","faxes":[{"id":19,"location_id":19,"number":"650
-        578-0440"}],"address":{"id":19,"location_id":19,"street":"19 West 39th Avenue","city":"San
-        Mateo","state":"CA","zip":"94403"},"description":"Provides free medical and
-        dental care to those in need. Offers basic medical care for adults.","name":"San
-        Mateo Free Medical Clinic","created_at":"2014-04-18T12:32:11.266-07:00","slug":"san-mateo-free-medical-clinic","longitude":-122.2931236,"latitude":37.5326941,"coordinates":[-122.2931236,37.5326941],"accessibility":["Elevator","Ramp","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[0.6741946265175476],"highlight":null,"_explanation":null}]'
+      string: '[{"id":19,"accessibility":["Elevator","Ramp","Wheelchair"],"address":{"id":19,"street":"19
+        West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"contacts":[{"id":27,"name":"Sharon
+        Petersen","title":"Administrator"}],"coordinates":[-122.2931236,37.5326941],"description":"Provides
+        free medical and dental care to those in need. Offers basic medical care for
+        adults.","emails":["smcmed@samaritanhouse.com"],"faxes":[{"id":19,"number":"650
+        578-0440"}],"hours":"Monday-Friday, 9-12, 1-4","languages":["Spanish"],"mail_address":{"id":19,"attention":"San
+        Mateo Free Medical/Dental","street":"19 West 39th Avenue","city":"San Mateo","state":"CA","zip":"94403"},"name":"San
+        Mateo Free Medical Clinic","phones":[{"id":19,"number":"650 578-0400"}],"short_desc":"Provides
+        free medical and dental care to those in need. Offers basic medical care for
+        adults.","slug":"san-mateo-free-medical-clinic","transportation":"SAMTRANS
+        stops within 1 block.","updated_at":"2014-05-09T21:37:14.734-07:00","urls":["http://www.samaritanhouse.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/19","services":[{"id":19,"eligibility":"Low-income
+        person without access to health care","fees":"None.","funding_sources":["Donations","Grants"],"keywords":["HEALTH
+        SERVICES","Outpatient Care","Community Clinics"],"how_to_apply":"Call for
+        screening appointment (650-347-3648).","service_areas":["Belmont","Burlingame","Foster
+        City","Millbrae","San Carlos","San Mateo"],"wait":"Varies.","updated_at":"2014-04-18T12:32:11.921-07:00"}],"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","url":"http://ohana-api-test.herokuapp.com/api/organizations/5","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/5/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:32 GMT
+  recorded_at: Fri, 16 May 2014 08:53:23 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/search_results_map/none_of_the_results_have_coordinates/does_not_display_a_results_list_map.yml
+++ b/spec/cassettes/search_results_map/none_of_the_results_have_coordinates/does_not_display_a_results_list_map.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&org_name=Location%20with%20no%20phone
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&org_name=Location%20with%20no%20phone
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,32 +23,32 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:52 GMT
+      - Fri, 16 May 2014 07:48:18 GMT
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
       - '1'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - a7197aee-3cff-4a3d-ab00-b29f6dfd4b7e
+      - 7f12c421-409b-4880-a142-b1e55865db57
       X-Runtime:
-      - '0.029919'
+      - '0.062562'
       X-Total-Count:
       - '1'
       X-Total-Pages:
       - '1'
       Content-Length:
-      - '422'
+      - '308'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"id":"20","organization":{"id":6,"name":"Location with no phone","slug":"location-with-no-phone","created_at":"2014-04-18T12:32:12.124-07:00","updated_at":"2014-04-18T12:32:12.475-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"},"services":[{"id":20,"updated_at":"2014-04-18T12:32:12.259-07:00"}],"updated_at":"2014-04-18T12:32:12.272-07:00","mail_address":{"id":20,"location_id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"description":"no
-        phone","name":"Location with no phone","created_at":"2014-04-18T12:32:12.179-07:00","slug":"location-with-no-phone","short_desc":"no
-        phone","url":"http://ohana-api-test.herokuapp.com/api/locations/20","kind":"Test","_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397849532179],"highlight":null,"_explanation":null}]'
+      string: '[{"id":20,"description":"no phone","mail_address":{"id":20,"attention":"","street":"puma","city":"fairfax","state":"VA","zip":"22031"},"name":"Location
+        with no phone","short_desc":"no phone","slug":"location-with-no-phone","updated_at":"2014-05-09T22:11:56.835-07:00","url":"http://ohana-api-test.herokuapp.com/api/locations/20","services":[{"id":20,"updated_at":"2014-05-09T22:11:56.825-07:00"}],"organization":{"id":6,"name":"Location
+        with no phone","slug":"location-with-no-phone","url":"http://ohana-api-test.herokuapp.com/api/organizations/6","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/6/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:52 GMT
+  recorded_at: Fri, 16 May 2014 07:48:18 GMT
 recorded_with: VCR 2.9.0

--- a/spec/cassettes/search_results_map/results_have_entries_that_have_coordinates/displays_a_results_list_map.yml
+++ b/spec/cassettes/search_results_map/results_have_entries_that_have_coordinates/displays_a_results_list_map.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations
     body:
       encoding: US-ASCII
       string: ''
@@ -11,8 +11,6 @@ http_interactions:
       - application/vnd.ohanapi-v1+json
       User-Agent:
       - Ohanakapa Ruby Gem 1.0.0
-      X-Api-Token:
-      - "<API_TOKEN>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -25,13 +23,13 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 09 May 2014 22:24:52 GMT
+      - Fri, 16 May 2014 07:48:17 GMT
       Link:
-      - <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=22>;
-        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&api_token=<API_TOKEN>&controller=organizations&page=2>;
+      - <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=22&per_page=1>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?action=index&controller=organizations&page=2&per_page=1>;
         rel="next"
       Server:
-      - nginx/1.4.7 + Phusion Passenger 4.0.40
+      - nginx/1.4.7 + Phusion Passenger 4.0.41
       Status:
       - 200 OK
       X-Current-Page:
@@ -39,80 +37,60 @@ http_interactions:
       X-Next-Page:
       - '2'
       X-Powered-By:
-      - Phusion Passenger 4.0.40
+      - Phusion Passenger 4.0.41
       X-Request-Id:
-      - 47d677f7-1c17-4986-ab17-dca87cb1e956
+      - 0c40e2a3-f2ec-46f4-8907-7bf4b3a195de
       X-Runtime:
-      - '0.020985'
+      - '0.051700'
       X-Total-Count:
       - '22'
       X-Total-Pages:
       - '22'
-      Content-Length:
-      - '1753'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"services":[{"id":23,"audience":"Second service and nonprofit businesses,
-        the public, military facilities, schools and government entities","description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","eligibility":"None","fees":"None,
-        except for permits and photocopying. Cash, checks and credit cards accepted","how_to_apply":"Walk
-        in or apply by phone or mail","name":"hasdfasf","urls":["http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.850-07:00"},{"id":22,"audience":"Profit
-        and nonprofit businesses, the public, military facilities, schools and government
-        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
-        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
-        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
-        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
-        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
-        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
-        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
-        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
-        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
-        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
-        Cash, checks and credit cards accepted","how_to_apply":"Walk in or apply by
-        phone or mail","name":"bazfoo","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
-        wait to 2 weeks","funding_sources":["City","County","Federal","State"],"service_areas":["San
-        Mateo County","Alameda County","Contra Costa County","Marin County","San Francisco
-        County","Santa Clara County"],"keywords":["Ruby on Rails/MongoDB/Redis","FIFA
-        World Cup"],"updated_at":"2014-04-18T12:49:47.791-07:00"}],"mail_address":{"id":21,"location_id":22,"attention":"Hella
-        Fellas","street":"2013 Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"hours":"Monday-Friday,
-        8-5; Saturday, 10-6; Sunday 11-5","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"transportation":"SAMTRANS
-        stops within 1 block","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS
-        FOR TESTING PURPOSES OF THIS ALPHA APP]","url":"http://ohana-api-test.herokuapp.com/api/locations/22","phones":[{"id":21,"location_id":22,"number":"650
-        372-6200","department":"Information"},{"id":22,"location_id":22,"number":"650
-        372-6200","department":"Reservations"}],"contacts":[{"id":29,"location_id":22,"name":"Suzanne
-        Badenhoop","title":"Board President"}],"id":"22","languages":["Chinese (Cantonese)","Chinese
-        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"organization":{"id":8,"name":"SanMaceo
-        Example Agency.","slug":"sanmaceo-example-agency","created_at":"2014-04-18T12:49:47.008-07:00","updated_at":"2014-04-18T12:49:47.918-07:00","url":"http://ohana-api-test.herokuapp.com/api/organizations/8","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/8/locations"},"updated_at":"2014-04-18T12:49:47.528-07:00","faxes":[{"id":21,"location_id":22,"number":"650
-        627-8244"}],"address":{"id":21,"location_id":22,"street":"2013 Avenue of the
-        fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"description":"[NOTE
-        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
-        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
-        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
-        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
-        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
-        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
-        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
-        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
-        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
-        in. Phasellus nec purus sit amet sapien volutpat egestas.","name":"San Maceo
-        Agency","created_at":"2014-04-18T12:49:47.528-07:00","slug":"san-maceo-agency","longitude":-73.1968254,"latitude":42.878036,"coordinates":[-73.1968254,42.878036],"accessibility":["Disabled
-        Restroom","Disabled Parking","Wheelchair"],"_score":null,"_type":"location","_index":"production-ohana_api","_version":null,"sort":[1397850587528],"highlight":null,"_explanation":null}]'
+      string: '[{"id":1,"accessibility":["Ramp","Disabled Restroom","Disabled Parking","Wheelchair"],"address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"contacts":[{"id":1,"name":"Susan
+        Houston","title":"Director of Older Adult Services"},{"id":2,"name":"Christina
+        Gonzalez","title":"Center Director"}],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","emails":["cgonzalez@peninsulafamilyservice.org"],"faxes":[{"id":1,"number":"650
+        701-0856"}],"hours":"Monday-Friday, 9-5","languages":["Filipino (Tagalog)","Spanish"],"mail_address":{"id":1,"attention":"Fair
+        Oaks Intergenerational Center","street":"2600 Middlefield Road","city":"Redwood
+        City","state":"CA","zip":"94063"},"name":"Fair Oaks Adult Activity Center","phones":[{"id":1,"number":"650
+        780-7525"}],"short_desc":"A multipurpose senior citizens'' center serving
+        the Redwood City area.","slug":"fair-oaks-adult-activity-center","transportation":"SAMTRANS
+        stops in front.","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"url":"http://ohana-api-test.herokuapp.com/api/locations/1","services":[{"id":1,"audience":"Older
+        adults age 55 or over, ethnic minorities and low-income persons","eligibility":"Age
+        55 or over for most programs, age 60 or over for lunch program","fees":"$2.50
+        suggested donation for lunch for age 60 or over, donations for other services
+        appreciated. Cash and checks accepted.","funding_sources":["City","County","Donations","Fees","Fundraising"],"keywords":["ADULT
+        PROTECTION AND CARE SERVICES","Meal Sites/Home-delivered Mea","COMMUNITY SERVICES","Group
+        Support","Information and Referral","EDUCATION SERVICES","English Language","RECREATION/LEISURE
+        SERVICES","Arts and Crafts","Sports/Games/Exercise","Brown Bag Food Programs","Congregate
+        Meals/Nutrition Sites","Senior Centers","Older Adults"],"how_to_apply":"Walk
+        in or apply by phone.","service_areas":["Redwood City"],"wait":"No wait.","updated_at":"2014-04-18T12:31:54.284-07:00"}],"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","url":"http://ohana-api-test.herokuapp.com/api/organizations/1","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/1/locations"}}]'
     http_version: 
-  recorded_at: Fri, 09 May 2014 22:24:52 GMT
+  recorded_at: Fri, 16 May 2014 07:48:17 GMT
 recorded_with: VCR 2.9.0

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -22,18 +22,16 @@ describe StatusController do
       end
 
       it "returns API failure error" do
-        stub_request(:get, "http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic?api_token=#{ENV["OHANA_API_TOKEN"]}").
+        stub_request(:get, "http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic").
           with(:headers => {'Accept'=>'application/vnd.ohanapi-v1+json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0',
-            'X-Api-Token'=>"#{ENV["OHANA_API_TOKEN"]}"}).
+            'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0'}).
           to_return(:status => 200, :body => "", :headers => {})
 
-        stub_request(:get, "http://ohana-api-test.herokuapp.com/api/search?api_token=#{ENV["OHANA_API_TOKEN"]}&keyword=maceo").
+        stub_request(:get, "http://ohana-api-test.herokuapp.com/api/search?keyword=maceo").
           with(:headers => {'Accept'=>'application/vnd.ohanapi-v1+json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0',
-            'X-Api-Token'=>"#{ENV["OHANA_API_TOKEN"]}"}).
+            'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0'}).
           to_return(:status => 200, :body => "", :headers => {})
 
         get "get_status"

--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -108,7 +108,7 @@ feature "location details" do
       # the time is checked against the Travis CI server time. The time has been
       # removed from the test till this can be sorted.
       #expect(page).to have_content("Tuesday, 1 October 2013 at 3:18 PM")
-      expect(page).to have_content("Friday, 18 April 2014 at")
+      expect(page).to have_content("Friday, 16 May 2014 at")
     end
 
   end

--- a/spec/features/search/filters_spec.rb
+++ b/spec/features/search/filters_spec.rb
@@ -140,23 +140,22 @@ feature "results page search", :js, :vcr do
     expect(page).to have_content("22 results")
     visit("/organizations?page=3")
 
-    within(".require-loaded") do
-      within("#org-name-options") do
-        find(".closed").click
-        find(".toggle-group", :text => "SanMaceo Example Agency").click
-      end
+    find(".require-loaded")
+    within("#org-name-options") do
+      find(".closed").click
+      find(".toggle-group", :text => "Peninsula Family Service").click
     end
     find('#find-btn').click
 
-    expect(page).to have_content("1 result")
-    expect(all("#org-name-options .current-option label").last).to have_content("SanMaceo Example Agency")
+    expect(page).to have_content("5 results")
+    expect(all("#org-name-options .current-option label").last).to have_content("Peninsula Family Service")
   end
 
   # user clicks filter links in results list
   scenario 'when clicking organization link in results' do
     search(:keyword => "Samaritan House")
     first("#list-view li").click_link("Samaritan House")
-    expect(page).to have_content("San Mateo Free Medical Clinic")
+    expect(page).to have_content("Redwood City Free Medical Clinic")
 
     # check filter settings
     expect(all("#location-options .current-option label").last).to have_content("All")

--- a/spec/features/search/homepage_search_spec.rb
+++ b/spec/features/search/homepage_search_spec.rb
@@ -38,6 +38,6 @@ feature "homepage search" do
   scenario "when clicking a category", :vcr do
     visit("/")
     click_link("Health Insurance")
-    expect(page).to have_content("Fair Oaks Adult Activity Center")
+    expect(page).to have_content("Little House")
   end
 end


### PR DESCRIPTION
Pull requests coming from forks were failing on Travis. This commit:
- removes the api token from .travis.yml, because it’s not needed for tests
  on Travis.
- updates cassettes to remove the api_token in the URL call.
- updates the status_controller_spec to remove the api_token in the URL call.
- updates the tests that weren't correctly expecting 1 result per page returned.
