### PR TITLE
Don't use the API token for tests

### DIFF
--- a/config/initializers/ohanapi.rb
+++ b/config/initializers/ohanapi.rb
@@ -4,7 +4,7 @@ stack = Faraday::Builder.new do |builder|
   builder.adapter Faraday.default_adapter
 end
 Ohanakapa.configure do |config|
-  config.api_token = ENV["OHANA_API_TOKEN"]
+  config.api_token = ENV["OHANA_API_TOKEN"] unless Rails.env.test?
 
   if Rails.env.test?
     config.api_endpoint = "http://ohana-api-test.herokuapp.com/api"


### PR DESCRIPTION
If OHANA_API_TOKEN is set in application.yml, the specs will fail because the app will be adding an `api_token` parameter to the request URL, but the cassettes don't have that parameter recorded.
