### PR TITLE
Insert Rack::Rewrite before Rack::Runtime, not Rack::Lock

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ HumanServicesFinder::Application.configure do
   # config/environments/development.rb and restart your server.
   # Don't forget to remove the redirection code from development.rb
   # when you're done testing.
-  config.middleware.insert_before(Rack::Lock, Rack::Rewrite) do
+  config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
     if ENV["CANONICAL_URL"].blank?
       raise "The CANONICAL_URL environment variable is not set on your"+
       " production server. It should be set to your app's domain name,"+


### PR DESCRIPTION
In Rails 4, Rack::Lock is not present on production because thread safety is enabled by default. Attempting to push to Heroku while trying to insert middleware before Rack::Lock will yield this error:

No such middleware to insert before: Rack::Lock

Reference: https://github.com/jtrupiano/rack-rewrite#sample-usage-in-a-rails-app
