### PR TITLE
Fixes #424 - phone type alignment

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -2204,6 +2204,10 @@ body { top: 0px !important; }
     {
       font-size: $font_size_90;
       color: $greyscale_midtone;
+
+      // Set line height equal to the height of the adjacent text
+      line-height: $font_size_100;
+      vertical-align: text-top;
     }
   }
 


### PR DESCRIPTION
The phone type (e.g. TTY) was bottom-aligned to its adjacent phone
number, which affected the line height. This commit top aligns it but
explicitly setting its line height to that of the baseline font height
and setting the vertical alignment to the top of the phone number text.
