### PR TITLE
Fix Rails 4 asset pipeline issues. Fixes #429.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ group :production, :staging do
   gem 'rails_12factor'
 end
 
+gem 'sprockets_better_errors'
+
 # dev and debugging tools
 group :development do
   gem 'quiet_assets', '>= 1.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sprockets_better_errors (0.0.5)
+      actionpack (< 4.1)
+      activesupport (< 4.1)
+      sprockets-rails (>= 1.0.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
@@ -347,6 +351,7 @@ DEPENDENCIES
   rspec-rails (>= 2.14.2)
   sass-rails (~> 4.0.2)
   selectivizr-rails (>= 1.1.2)
+  sprockets_better_errors
   uglifier (>= 2.5.0)
   unicorn (>= 4.8.3)
   vcr (>= 2.9.0)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
     <%= render 'component/status/alert' %>
 
     <header id="content-header">
-      <h1 id="logo"><a href="/" target="_self"><img src="/assets/smc_connect_logo.png" width="231" height="42" alt="SMC-Connect" /></a></h1>
+      <h1 id="logo"><a href="/" target="_self"><img src="<%= asset_path('smc_connect_logo.png') %>" width="231" height="42" alt="SMC-Connect" /></a></h1>
       <h2>Find San Mateo County community services</h2>
       <nav>
         <ul>
@@ -92,7 +92,7 @@
     <footer id='app-footer'>
 
       <p id="hsa-logo">
-        <a href='http://www.co.sanmateo.ca.us/portal/site/humanservices' target='_blank' title='San Mateo County Human Services Agency'><img src="/assets/smc_hsa_logotype.png" width="200" height="38" alt="San Mateo County Human Services Agency" /></a>
+        <a href='http://www.co.sanmateo.ca.us/portal/site/humanservices' target='_blank' title='San Mateo County Human Services Agency'><img src="<%= asset_path('smc_hsa_logotype.png') %>" width="200" height="38" alt="San Mateo County Human Services Agency" /></a>
       </p>
 
       <p>A <a href='http://codeforamerica.org' target='_blank' title='Code for America'>Code for America</a> project <span class='cfaflag'></span> in partnership with the <a href='http://www.co.sanmateo.ca.us/portal/site/humanservices' target='_blank' title='San Mateo County Human Services agency'>San Mateo County Human Services Agency</a>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,6 @@ module HumanServicesFinder
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.assets.precompile += %w(selectivizr html5shiv-printshiv)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,4 +53,7 @@ HumanServicesFinder::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # For use with the sprockets_better_errors gem.
+  # Remove this and the gem after upgrading to Rails 4.1+.
+  config.assets.raise_production_errors = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,7 +70,9 @@ HumanServicesFinder::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  # This should be set to true, especially when using a cache store on Heroku,
+  # such as Memcached.
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor  = :uglifier
@@ -120,9 +122,9 @@ HumanServicesFinder::Application.configure do
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  #config.assets.precompile << "*.js"
-  config.assets.precompile << %w( *.svg *.eot *.woff *.ttf ) # fonts
-  config.assets.precompile << %w( html5shiv.js html5shiv-printshiv.js ) #polyfill
+  # config.assets.precompile << "*.js"
+  config.assets.precompile << %w(*.svg *.eot *.woff *.ttf) # fonts
+  config.assets.precompile << %w(html5shiv.js) #polyfill
 
   # ActionMailer Config
   # Setup for production - deliveries, no errors raised


### PR DESCRIPTION
Made changes per this article:
https://devcenter.heroku.com/articles/rails-4-asset-pipeline

One main cause for the Heroku issues was that the config.serve_static_assets setting in production.rb was set to false during the Rails 4 upgrade.
