### PR TITLE
Process map marker JS assets through ERB

### DIFF
--- a/app/assets/javascripts/result/result-map-manager.js.erb
+++ b/app/assets/javascripts/result/result-map-manager.js.erb
@@ -127,7 +127,7 @@ define(['async!https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false!call
     {
       var myLatlng = new google.maps.LatLng(markerData['coordinates'][1],markerData['coordinates'][0]);
 
-      var markerIcon = '/assets/markers/human_services.png';
+      var markerIcon = "<%= asset_path('markers/human_services.png') %>";
 
       var marker = new google.maps.Marker({
         id: markerData['id'],


### PR DESCRIPTION
In rails 4, the assets include a digest only, so the reference to the
map markers used in the Google maps was not being properly referenced.
This commit runs the JS through ERB to retrieve the correct path to the
marker.
