### PR TITLE
Removes unused filter logic from view

### DIFF
--- a/app/views/component/search/_filter.html.haml
+++ b/app/views/component/search/_filter.html.haml
@@ -40,32 +40,18 @@
 
     - add_input_type = add_input_type ||= false
     - if add_input_type
-      - if add_input_type == "TEXT"
-        - add_is_checked = (all_is_checked == false && toggle_is_checked == false)
-        %div.toggle-group-wrapper.add
-          %div.toggle-group.add{:id=>"#{css_field}-toggle-group-1"}
-            %div.toggle
-              %div
-                %input{:type=>"radio", :name=>field, :id=>"#{css_field}-option-1",:checked=>(add_is_checked ? "checked" : false )}
-                %i{:class=>"fa fa-plus"}
-                %label{:for => "#{css_field}-option-1"}
-            %label{:for => "#{css_field}-option-1",:id => "#{css_field}-option-1-label"}
-              %span{:class=>(add_is_checked ? "hide" : "")}
-                Other...
-              = search_field_tag field, (add_is_checked ? params[field] : ""), id: "#{css_field}-option-input", :class=>(add_is_checked ? "" : "hide"), :list=>"#{css_field}-list", :placeholder=>"#{add_placeholder}"
-      - elsif add_input_type == "SELECT"
-        - add_is_checked = (all_is_checked == false && toggle_is_checked == false)
-        %div.toggle-group-wrapper.add
-          %div.toggle-group.add{:id=>"#{css_field}-toggle-group-1"}
-            %div.toggle
-              %div
-                %input{:type=>"radio", :name=>field, :id=>"#{css_field}-option-1",:checked=>(add_is_checked ? "checked" : false )}
-                %i{:class=>"fa fa-plus"}
-                %label{:for => "#{css_field}-option-1"}
-            %label{:for => "#{css_field}-option-1",:id => "#{css_field}-option-1-label"}
-              %span{:class=>(add_is_checked ? "hide" : "")}
-                Other...
-              = select_tag field, options_for_select(list_values, selected: :option), id: "#{css_field}-option-input"
+      - add_is_checked = (all_is_checked == false && toggle_is_checked == false)
+      %div.toggle-group-wrapper.add
+        %div.toggle-group.add{:id=>"#{css_field}-toggle-group-1"}
+          %div.toggle
+            %div
+              %input{:type=>"radio", :name=>field, :id=>"#{css_field}-option-1",:checked=>(add_is_checked ? "checked" : false )}
+              %i{:class=>"fa fa-plus"}
+              %label{:for => "#{css_field}-option-1"}
+          %label{:for => "#{css_field}-option-1",:id => "#{css_field}-option-1-label"}
+            %span{:class=>(add_is_checked ? "hide" : "")}
+              Other...
+            = search_field_tag field, (add_is_checked ? params[field] : ""), id: "#{css_field}-option-input", :class=>(add_is_checked ? "" : "hide"), :list=>"#{css_field}-list", :placeholder=>"#{add_placeholder}"
 
     - toggle_is_checked = false
     - length = aggregate_field.length-1

--- a/app/views/component/search/_options.html.haml
+++ b/app/views/component/search/_options.html.haml
@@ -1,5 +1,5 @@
 %section#search-options
 
-  = render :partial => "component/search/filter", :locals => {:field=>"location", :legend=>"Near Address",:field_value=>params[:location], :aggregate_field=>@aggregate_locations, :add_placeholder=>"address", :add_input_type=>"TEXT"}
+  = render :partial => 'component/search/filter', :locals => { field: 'location', legend: 'Near Address', field_value: params[:location], aggregate_field: @aggregate_locations, add_placeholder: 'address', add_input_type: true }
 
-  = render :partial => "component/search/filter", :locals => {:field=>"org_name", :legend=>"Agency Name",:field_value=>params[:org_name], :aggregate_field=>@aggregate_org_names, :add_placeholder=>"agency name", :add_input_type=>"TEXT"}
+  = render :partial => 'component/search/filter', :locals => { field: 'org_name', legend: 'Agency Name', field_value: params[:org_name], aggregate_field: @aggregate_org_names, add_placeholder: 'agency name', add_input_type: true }


### PR DESCRIPTION
- Removes logic for a select menu (which is unused) from filter view. Ties into #425.
- Adds rubocop-style code formatting to filters code.
