### PR TITLE
Fixes #436 - styles FAX text

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -2042,7 +2042,10 @@ body { top: 0px !important; }
           >.fax:after,
           >.fax::after
           {
-            content: "℻";
+            content: "FAX";
+            font-size: 10px;
+            font-family: $font_san_serif;
+            @include inline-block();
           }
         }
       }


### PR DESCRIPTION
Checked in:

Chrome, FF, Opera, Safari, IE8-10, iOS

![screen shot 2014-06-08 at 11 24 56 pm](https://cloud.githubusercontent.com/assets/704760/3213835/d3034e12-ef9e-11e3-8778-b0f96cdf55b5.png)
