### PR TITLE
Fixes #396 input-line-height

### DIFF
--- a/app/assets/stylesheets/components/_input-search.scss
+++ b/app/assets/stylesheets/components/_input-search.scss
@@ -55,7 +55,7 @@
 
   > input[type=search]
   {
-    @include type-size(base-medium);
+    font-size: $font_size_105;
     margin-left: 0px;
     height: 40px;
     padding: 3px;
@@ -162,7 +162,7 @@
     padding: 10px;
     padding-right: 144px;
     margin:0;
-    @include type-size(medium);
+    font-size: $font_size_110;
     vertical-align:middle;
     background: $white;
     @include border-radius(4px);


### PR DESCRIPTION
Removes line-height that was being injected into the vertical rhythm, leading to vertical alignment issues in some browsers for the search input fields.
