### PR TITLE
Update ohanakapa gem to version 1.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'haml-rails', '>= 0.5.3'
 
 gem 'unicorn', '>= 4.8.3'
 gem 'newrelic_rpm', '>= 3.8.0.218'
-gem 'ohanakapa', '~> 1.0'
+gem 'ohanakapa', '~> 1.1.1'
 gem 'faraday-http-cache', '>= 0.4.0'
 
 # Caching

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     newrelic_rpm (3.8.1.221)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
-    ohanakapa (1.0.0)
+    ohanakapa (1.1.1)
       sawyer (~> 0.3.0)
     parallel (1.0.0)
     polyglot (0.3.4)
@@ -336,7 +336,7 @@ DEPENDENCIES
   memcachier
   metric_fu (>= 4.11.0)
   newrelic_rpm (>= 3.8.0.218)
-  ohanakapa (~> 1.0)
+  ohanakapa (~> 1.1.1)
   quiet_assets (>= 1.0.2)
   rack-cache (>= 1.2)
   rack-rewrite (>= 1.5.0)

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -25,13 +25,13 @@ describe StatusController do
         stub_request(:get, "http://ohana-api-test.herokuapp.com/api/locations/san-mateo-free-medical-clinic").
           with(:headers => {'Accept'=>'application/vnd.ohanapi-v1+json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0'}).
+            'User-Agent'=>'Ohanakapa Ruby Gem 1.1.1'}).
           to_return(:status => 200, :body => "", :headers => {})
 
         stub_request(:get, "http://ohana-api-test.herokuapp.com/api/search?keyword=maceo").
           with(:headers => {'Accept'=>'application/vnd.ohanapi-v1+json',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent'=>'Ohanakapa Ruby Gem 1.0.0'}).
+            'User-Agent'=>'Ohanakapa Ruby Gem 1.1.1'}).
           to_return(:status => 200, :body => "", :headers => {})
 
         get "get_status"


### PR DESCRIPTION
This includes a security fix to redact the API Token from error logs.
