### PR TITLE
Hotfix to fix bug in JS async plugin syntax

### DIFF
--- a/app/assets/javascripts/detail/detail-map-manager.js.erb
+++ b/app/assets/javascripts/detail/detail-map-manager.js.erb
@@ -1,9 +1,10 @@
 //= depend_on_asset 'markers/marker_large.png'
 // Manages location detail view Google Map.
-define(['async!https://maps.googleapis.com/maps/api/' +
-        'js?v=3.exp&sensor=false!callback',
-        'domReady!'],
-        function () {
+define([
+  'domReady!',
+  'async!https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false!callback'
+],
+function () {
   'use strict';
 
   var _map;

--- a/app/assets/javascripts/result/result-map-manager.js.erb
+++ b/app/assets/javascripts/result/result-map-manager.js.erb
@@ -3,11 +3,12 @@
 //= depend_on_asset 'markers/marker_large_spiderfied.png'
 //= depend_on_asset 'markers/marker_small_spiderfied.png'
 // Manages search results view Google Map.
-define(['util/bitmask',
-        'domReady!',
-        'async!https://maps.googleapis.com/maps/api/' +
-        'js?v=3.exp&sensor=false!callback'],
-        function (bitmask) {
+define([
+  'util/bitmask',
+  'domReady!',
+  'async!https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false!callback'
+],
+function (bitmask) {
   'use strict';
 
   // The <div> element that the Google map loads into.

--- a/app/assets/javascripts/util/geolocation/geolocate-action.js.erb
+++ b/app/assets/javascripts/util/geolocation/geolocate-action.js.erb
@@ -1,10 +1,11 @@
 // Manages geolocation action, which can be associated with a button.
-define(['util/geolocation/geolocator',
-        'app/alert-manager',
-        'domReady!',
-        'async!https://maps.googleapis.com/maps/api/' +
-        'js?v=3.exp&sensor=false!callback'],
-        function (geo, alert) {
+define([
+  'util/geolocation/geolocator',
+  'app/alert-manager',
+  'domReady!',
+  'async!https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false!callback'
+],
+function (geo, alert) {
   'use strict';
 
   var _locateTarget; // locate current location button.


### PR DESCRIPTION
The asset pipeline optimizer didn’t like the Google URL broken across
two lines, causing the async plugin not to load properly. This commit
formats the URL to fit on one line.

@monfresh FYI going to merge this, pull from master for your work.
