### PR TITLE
Allow Travis to run from external pull requests.

### DIFF
--- a/bin/wad
+++ b/bin/wad
@@ -24,7 +24,7 @@ class Presss
 
     # Returns the value for the Authorization header for a message contents.
     def header(string)
-      'AWS ' + access_key_id + ':' + sign(string)
+      'AWS ' + access_key_id + ':' + sign(string) if access_key_id
     end
 
     # Returns a signature for a AWS request message.
@@ -114,10 +114,10 @@ class Presss
     # Returns the request headers for a date, message and content-type.
     def headers(date, message, content_type=nil)
       headers = {
-        'Authorization' => authorization.header(message),
         'Date' => date,
         'User-Agent' => 'Press/0.9'
       }
+      headers['Authorization'] = authorization.header(message) if authorization.header(message)
       headers['Content-Type'] = content_type if content_type
       headers
     end
@@ -329,10 +329,10 @@ class Wad
   def s3_configure
     Presss.config = {
       :region => s3_region,
-      :bucket_name => s3_bucket_name,
-      :access_key_id => s3_access_key_id,
-      :secret_access_key => s3_secret_access_key
+      :bucket_name => s3_bucket_name
     }
+    Presss.config[:access_key_id] = s3_access_key_id if ENV['S3_CREDENTIALS']
+    Presss.config[:secret_access_key] = s3_secret_access_key if ENV['S3_CREDENTIALS']
   end
 
   def s3_write_streaming
@@ -4220,4 +4220,3 @@ i4TWnsLrgxifarsbJGAzcMzs9zLzXNl5fe+epP7JI8Mk7hWSsT2RTyaGvWZzJBPqpK5jwa19hAM8
 EHiGG3njxPPyBJUgriOCxLM6AGK/5jYk4Ve6xx6QddVfP5VhK8E7zeWzaGHQRiapIVJpLesux+t3
 zqY6tQMzT3bR51xUAV3LePTJDL/PEo4XLSNolOer/qmyKwbQBM0=
 -----END CERTIFICATE-----
-


### PR DESCRIPTION
By default, the `bin/wad` script sets an Authorization header using S3
credentials for both read and write operations. The problem is that pull
requests from forks can't use secure credentials on Travis, so all
Travis runs from external PRs will fail.

What gets stored on S3 is just a zipped up tarball of all the gems,
so it's perfectly safe to allow anyone to download the files from S3.
This commit modifies the script so that it only sets the Authorization
header during a write operation. On the S3 side, a policy was added to
the bucket to allow anonymous downloads:
http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html
