### PR TITLE
Fixes #547 - geolocation button disabled state

### DIFF
--- a/app/assets/javascripts/util/geolocation/geolocate-action.js.erb
+++ b/app/assets/javascripts/util/geolocation/geolocate-action.js.erb
@@ -8,13 +8,21 @@ define([
 function (geo, alert) {
   'use strict';
 
-  var _locateTarget; // locate current location button.
-  var _locateAction; // a callback function for the location is determined.
+
+  // Locate current geolocation button.
+  var _locateTarget;
+
+  // The text in the geolocation button.
+  var _locateTargetTextContainer;
+
+  // A callback function for when the location is determined.
+  var _locateAction;
 
   function init(target, locateAction) {
     // If geolocation is supported, show geolocate button.
     if (navigator.geolocation) {
       _locateTarget = document.getElementById(target);
+      _locateTargetTextContainer = _locateTarget.querySelector('span');
       _locateAction = locateAction;
 
       _locateTarget.addEventListener('click', _currLocationAction, false);
@@ -24,9 +32,7 @@ function (geo, alert) {
   // Target element was clicked.
   function _currLocationAction(evt) {
     evt.preventDefault();
-    var waitText = _locateTarget.getAttribute('data-wait-text');
-    _locateTarget.querySelector('span').innerHTML = waitText;
-    _locateTarget.setAttribute('disabled', 'disabled');
+    _locateTargetBusy();
     _locateUser();
   }
 
@@ -42,8 +48,7 @@ function (geo, alert) {
       error: function(error) { // jshint ignore:line
         //console.log("Geolocation failed due to: " + error.message);
         alert.show("Your location could not be determined!");
-        var regularText = _locateTarget.getAttribute('data-regular-text');
-        _locateTarget.querySelector('span').innerHTML = regularText;
+        _locateTargetReady();
       }
     };
 
@@ -61,8 +66,23 @@ function (geo, alert) {
       } else {
         //console.log("Geocoder failed due to: " + status);
         alert.show('Your location could not be determined!');
+        _locateTargetReady();
       }
     });
+  }
+
+  // Set content of button to busy state.
+  function _locateTargetBusy() {
+    var waitText = _locateTarget.getAttribute('data-wait-text');
+    _locateTargetTextContainer.innerHTML = waitText;
+    _locateTarget.setAttribute('disabled', 'disabled');
+  }
+
+  // Set content of button to ready state.
+  function _locateTargetReady() {
+    var regularText = _locateTarget.getAttribute('data-regular-text');
+    _locateTargetTextContainer.innerHTML = regularText;
+    _locateTarget.removeAttribute('disabled');
   }
 
   return {

--- a/app/assets/stylesheets/components/_input-search.scss
+++ b/app/assets/stylesheets/components/_input-search.scss
@@ -266,6 +266,19 @@
         color: $search-button-fa-hover-color;
       }
     }
+
+    // Prevent hover state appearance when 'disabled' attribute is present.
+    &[disabled]
+    {
+      background: rgba($white, 0.3);
+      border: 1px solid rgba($white, 0);
+      cursor: auto;
+
+      .fa
+      {
+        color: $input-fa-color;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Geolocation button still appeared clickable after an error. This commit
adds styles to override the hover state when the `disabled` attribute
is present on the button. It also performs some cleanup of the
geolocation-action script by:
- Formatting and adding additional code comments.
- Moving the geolocation button content to a variable.
- Moving the disable/enable content of the geolocation button to its
  own functions.

It also adds the ability to re-run the geolocation check after an error
so the user can re-check for geolocation if they had a temporary
connection failure that prevented geolocation for the first check.
