### PR TITLE
Fixes #546 - cleans up title attribute

### DIFF
--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -4,11 +4,11 @@
 
   %header
     %hgroup
-      %h1.name{ title: @location.name, itemprop: 'name' }
+      %h1.name{ itemprop: 'name' }
         = superscript_ordinals(@location.name)
       - if (@location.organization.name) && (@location.organization.name != @location.name)
         %h2.agency
-          = link_to(locations_path(org_name: @location.organization.name), title: @location.organization.name) do
+          = link_to(locations_path(org_name: @location.organization.name)) do
             %span
               = superscript_ordinals(@location.organization.name)
 

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -9,11 +9,11 @@
           %header
             %hgroup
               %h1{ class: 'name' }
-                %a{ href: (location.organization.name == location.name) ? "#{location_path([location.slug], request.query_parameters)}" : "#{location_path([location.organization.slug, location.slug], request.query_parameters)}", title: "#{location.name}", name: "#{location.id}", itemprop: 'name' }
+                %a{ href: (location.organization.name == location.name) ? "#{location_path([location.slug], request.query_parameters)}" : "#{location_path([location.organization.slug, location.slug], request.query_parameters)}", name: "#{location.id}", itemprop: 'name' }
                   = superscript_ordinals(location.name)
               - if (location.organization.name) && (location.organization.name != location.name)
                 %h2.agency
-                  = link_to(locations_path(org_name: location.organization.name), title: location.organization.name) do
+                  = link_to(locations_path(org_name: location.organization.name)) do
                     %span
                       = superscript_ordinals(location.organization.name)
 

--- a/app/views/component/search/_agency.html.haml
+++ b/app/views/component/search/_agency.html.haml
@@ -1,6 +1,6 @@
 = field_set_tag nil, id: 'org-name-options', class: 'input-search-filter' do
   = label_tag 'org_name', t('labels.agency_search')
   = content_tag :div, '', class: 'filter-input-group clearable' do
-    = button_tag(type: 'submit', name: nil, class: 'button-icon') do
+    = button_tag(type: 'submit', name: nil, class: 'button-icon', title: 'Update search results') do
       = content_tag :i, '', class: 'fa fa-institution'
     = search_field_tag :org_name, params[:org_name], placeholder: t('placeholders.agency_search')

--- a/app/views/component/search/_aside.html.haml
+++ b/app/views/component/search/_aside.html.haml
@@ -3,7 +3,7 @@
     = form_tag('/locations', method: :get, id: 'form-search') do
       %section#keyword-search-box
         .input-search-small.clearable
-          = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'button-icon', title: 'Search') do
+          = button_tag(type: 'submit', name: nil, id: 'button-search', class: 'button-icon', title: 'Update search results') do
             %i{ class: 'fa fa-search' }
           = search_field_tag :keyword, params[:keyword], placeholder: t('placeholders.results_page_keyword_search')
 

--- a/app/views/component/search/_location.html.haml
+++ b/app/views/component/search/_location.html.haml
@@ -1,7 +1,7 @@
 = field_set_tag nil, id: 'location-options', class: 'input-search-filter input-search-filter-option' do
   = label_tag 'location', t('labels.address_search')
   = content_tag :div, '', class: 'filter-input-group clearable' do
-    = button_tag(type: 'submit', name: nil, class: 'button-icon') do
+    = button_tag(type: 'submit', name: nil, class: 'button-icon', title: 'Update search results') do
       = content_tag :i, '', class: 'fa fa-map-marker'
     = search_field_tag :location, params[:location], placeholder: t('placeholders.address_search')
   = render 'component/search/geolocate', context_class: 'input-search-filter-option'

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 
-= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', title: 'next', remote: remote
+= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', title: 'Next page', remote: remote

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 
-= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', title: 'previous', remote: remote
+= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', title: 'Previous page', remote: remote

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,13 +1,13 @@
 %footer#app-footer
   %p
     A
-    %a{ href: 'http://codeforamerica.org', target: '_blank', title: 'Code for America' } Code for America
+    %a{ href: 'http://codeforamerica.org', target: '_blank' } Code for America
     project
     %span.cfaflag
     developed in partnership with the
-    %a{ href: 'http://www.co.sanmateo.ca.us/portal/site/humanservices', target: '_blank', title: 'San Mateo County Human Services agency' } San Mateo County Human Services Agency
-    and the
-    %a{ href: 'http://www.knightfoundation.org/grants/201447979/', target: '_blank', title: 'Knight Foundation Ohana API grant' } Knight Foundation
+    %a{ href: 'http://www.co.sanmateo.ca.us/portal/site/humanservices', target: '_blank' } San Mateo County Human Services Agency
+    and a
+    %a{ href: 'http://www.knightfoundation.org/grants/201447979/', target: '_blank' } grant from the Knight Foundation
     \.
 
   %p

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -6,11 +6,11 @@
   %nav
     %ul
       %li
-        %a#about-btn.popup-trigger{ title: 'Help',  href: '/about#about-box' } About
+        %a#about-btn.popup-trigger{ href: '/about#about-box' } About
       %li
-        %a#contribute-btn.popup-trigger{ title: 'Contribute', href: '/about#contribute-box', target: '_self' } Contribute
+        %a#contribute-btn.popup-trigger{ href: '/about#contribute-box', target: '_self' } Contribute
       %li
-        %a#feedback-btn.popup-trigger{ title: 'Feedback', href: '/about#feedback-box', target: '_self' } Feedback
+        %a#feedback-btn.popup-trigger{ href: '/about#feedback-box', target: '_self' } Feedback
   .clearfix
 
 -# Hide popups on /about because they are redundant to the content on that page.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,6 @@ en:
     pagination:
       first: "&laquo; First"
       last: "Last &raquo;"
-      previous: "<i class='fa fa-chevron-left' title='previous'></i>"
-      next: "<i class='fa fa-chevron-right' title='next'></i>"
+      previous: "<i class='fa fa-chevron-left'></i>"
+      next: "<i class='fa fa-chevron-right'></i>"
       truncate: "&hellip;"


### PR DESCRIPTION
- Removes `title` attribute where it is redundant with a link’s direct
  content.
- Adds `title` attribute to buttons that do not contain text content.
- Rewords footer text mentioning grant to make `title` attribute
  unnecessary.
- Removes `title` attribute from icons where a parent enclosing link also
  had the same `title` attribute.
- Normalizes `title` attribute text to capitalize first letter.
