### PR TITLE
Add HTTP caching to locations_controller

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -13,6 +13,8 @@ class LocationsController < ApplicationController
     # Populate the keyword search field with the original term
     # as typed by the user, not the translated word.
     params[:keyword] = translator.original_keyword
+
+    fresh_when(cache_settings(locations))
   end
 
   def show
@@ -21,5 +23,22 @@ class LocationsController < ApplicationController
 
     # @keywords = @location.services.map { |s| s[:keywords] }.flatten.compact.uniq
     @categories = @location.services.map { |s| s[:categories] }.flatten.compact.uniq
+
+    fresh_when last_modified: @location.updated_at, public: true
+  end
+
+  private
+
+  def cache_settings(locations)
+    return default_cache_settings(locations) if locations.blank?
+    default_cache_settings(locations).except(:etag)
+  end
+
+  def default_cache_settings(locations)
+    {
+      last_modified: locations.max_by(&:updated_at).try(:updated_at),
+      etag: locations,
+      public: true
+    }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,6 +52,56 @@ Rails.application.configure do
     end
   end
 
+  # --------------------------------------------------------------------------
+  # CACHING SETUP FOR RACK:CACHE AND MEMCACHIER ON HEROKU
+  # https://devcenter.heroku.com/articles/rack-cache-memcached-rails31
+  # ------------------------------------------------------------------
+
+  config.serve_static_assets = true
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
+  config.action_controller.perform_caching = true
+
+  config.cache_store = :dalli_store
+  client = Dalli::Client.new((ENV['MEMCACHIER_SERVERS'] || '').split(','),
+                             username: ENV['MEMCACHIER_USERNAME'],
+                             password: ENV['MEMCACHIER_PASSWORD'],
+                             failover: true,
+                             socket_timeout: 1.5,
+                             socket_failure_delay: 0.2,
+                             value_max_bytes: 10_485_760)
+  config.action_dispatch.rack_cache = {
+    metastore:   client,
+    entitystore: client
+  }
+  config.static_cache_control = 'public, max-age=2592000'
+  # --------------------------------------------------------------------------
+
+  # --------------------------------------------------------------------------
+  # EMAIL DELIVERY SETUP WITH MANDRILL ON HEROKU
+  # https://devcenter.heroku.com/articles/mandrill
+  # ----------------------------------------------
+
+  config.action_mailer.default_url_options = { host: ENV['CANONICAL_URL'] }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default charset: 'utf-8'
+
+  config.action_mailer.smtp_settings = {
+    port:           '587',
+    address:        'smtp.mandrillapp.com',
+    user_name:      ENV['MANDRILL_USERNAME'],
+    password:       ENV['MANDRILL_APIKEY'],
+    domain:         'heroku.com',
+    authentication: :plain
+  }
+  # ---------------------------------------------------------------------------
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 
@@ -62,18 +112,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
-  config.action_controller.perform_caching = true
-
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application.
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  # This should be set to true, especially when using a cache store on Heroku,
-  # such as Memcached.
-  config.serve_static_assets = true
+  config.consider_all_requests_local = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor  = :uglifier
@@ -83,9 +122,6 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
 
   # `config.assets.version` and `config.assets.precompile` have moved to config/initializers/assets.rb
 
@@ -108,39 +144,8 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-  config.cache_store = :dalli_store
-  client = Dalli::Client.new(ENV['MEMCACHIER_SERVERS'],
-                             value_max_bytes: 10_485_760)
-  config.action_dispatch.rack_cache = {
-    metastore:     client,
-    entitystore:   client
-  }
-  config.static_cache_control = 'public, max-age=2592000'
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
-
-  # ActionMailer Config
-  # Setup for production - deliveries, no errors raised
-  config.action_mailer.default_url_options = { host: 'ohana.herokuapp.com' }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.perform_deliveries = true
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default charset: 'utf-8'
-
-  config.action_mailer.smtp_settings = {
-    port:           '587',
-    address:        'smtp.mandrillapp.com',
-    user_name:      ENV['MANDRILL_USERNAME'],
-    password:       ENV['MANDRILL_APIKEY'],
-    domain:         'heroku.com',
-    authentication: :plain
-  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,32 +1,78 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
+  # This will password-protect your staging site so that search engines can't
+  # index it. If they were to index it, they would penalize your site for
+  # having duplicate content across two different sites.
+  # The username and password are stored in environment variables that you
+  # should set on your staging server. If you're deploying on Heroku, read this
+  # article to learn how to set environment (also called config) variables:
+  # https://devcenter.heroku.com/articles/config-vars
   config.middleware.use '::Rack::Auth::Basic' do |u, p|
     [u, p] == [ENV['STAGING_USER'], ENV['STAGING_PASSWORD']]
   end
+
+  # --------------------------------------------------------------------------
+  # CACHING SETUP FOR RACK:CACHE AND MEMCACHIER ON HEROKU
+  # https://devcenter.heroku.com/articles/rack-cache-memcached-rails31
+  # ------------------------------------------------------------------
+
+  config.serve_static_assets = true
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
+  config.action_controller.perform_caching = true
+
+  config.cache_store = :dalli_store
+  client = Dalli::Client.new((ENV['MEMCACHIER_SERVERS'] || '').split(','),
+                             username: ENV['MEMCACHIER_USERNAME'],
+                             password: ENV['MEMCACHIER_PASSWORD'],
+                             failover: true,
+                             socket_timeout: 1.5,
+                             socket_failure_delay: 0.2,
+                             value_max_bytes: 10_485_760)
+  config.action_dispatch.rack_cache = {
+    metastore:   client,
+    entitystore: client
+  }
+  config.static_cache_control = 'public, max-age=2592000'
+  # --------------------------------------------------------------------------
+
+  # --------------------------------------------------------------------------
+  # EMAIL DELIVERY SETUP WITH MANDRILL ON HEROKU
+  # https://devcenter.heroku.com/articles/mandrill
+  # ----------------------------------------------
+
+  config.action_mailer.default_url_options = { host: ENV['CANONICAL_URL'] }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default charset: 'utf-8'
+
+  config.action_mailer.smtp_settings = {
+    port:           '587',
+    address:        'smtp.mandrillapp.com',
+    user_name:      ENV['MANDRILL_USERNAME'],
+    password:       ENV['MANDRILL_APIKEY'],
+    domain:         'heroku.com',
+    authentication: :plain
+  }
+  # ---------------------------------------------------------------------------
 
   # Code is not reloaded between requests.
   config.cache_classes = true
 
   # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both thread web servers
+  # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
-  config.action_controller.perform_caching = true
-
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application.
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  # This should be set to true, especially when using a cache store on Heroku,
-  # such as Memcached.
-  config.serve_static_assets = true
+  config.consider_all_requests_local = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor  = :uglifier
@@ -36,9 +82,6 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
 
   # `config.assets.version` and `config.assets.precompile` have moved to config/initializers/assets.rb
 
@@ -61,42 +104,11 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-  config.cache_store = :dalli_store
-  client = Dalli::Client.new(ENV['MEMCACHIER_SERVERS'],
-                             value_max_bytes: 10_485_760)
-  config.action_dispatch.rack_cache = {
-    metastore:     client,
-    entitystore:   client
-  }
-  config.static_cache_control = 'public, max-age=2592000'
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
 
-  # ActionMailer Config
-  # Setup for production - deliveries, no errors raised
-  config.action_mailer.default_url_options = { host: 'ohana.herokuapp.com' }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.perform_deliveries = true
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default charset: 'utf-8'
-
-  config.action_mailer.smtp_settings = {
-    port:           '587',
-    address:        'smtp.mandrillapp.com',
-    user_name:      ENV['MANDRILL_USERNAME'],
-    password:       ENV['MANDRILL_APIKEY'],
-    domain:         'heroku.com',
-    authentication: :plain
-  }
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
+  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
@@ -107,5 +119,4 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
 end

--- a/config/initializers/ohanapi.rb
+++ b/config/initializers/ohanapi.rb
@@ -1,7 +1,7 @@
 cache_store = ActiveSupport::Cache.lookup_store(:dalli_store)
 
 stack = Faraday::RackBuilder.new do |builder|
-  builder.use Faraday::HttpCache, store: cache_store, logger: Rails.logger
+  builder.use Faraday::HttpCache, store: cache_store
   builder.use Ohanakapa::Response::RaiseError
   builder.adapter Faraday.default_adapter
 end


### PR DESCRIPTION
The server now includes a `Last-Modified` header, which the browser uses to ask the server if things have changed (via the `If-Modified-Since` Request header).

If the `Last-Modified` date has not changed, when a browser requests the same search results or location details page, the server will respond with a `304 Not Modified` and will skip rendering the view, thereby improving performance.

The page will be served from Memcache via the Memcachier add-on on Heroku. This means that any request for a page that has already been cached will be served from the cache, even when it comes from a different browser.

Other changes:
- Organize and document Caching and Email delivery setups in production.rb
- Document password protection in staging.rb
- Remove logging from ohanapi.rb
