### PR TITLE
Adds language links to footer

### DIFF
--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -585,7 +585,7 @@ sup {
 
 // The container for the Google Website Translator Gadget.
 #google-translate-container {
-  padding-bottom: 20px;
+  padding: 0px;
 }
 
 // Hides the Google Translate translation banner at the top of the page.
@@ -613,8 +613,8 @@ body {
 }
 
 //=================================================================================
-// Language translation links on the upper-right homepage.
-.home #language-box {
+// Language translation links on the upper-right homepage and in the footer.
+.home #search-top-utilities .language-box {
   padding-bottom: 10px;
 
   ul {
@@ -625,6 +625,22 @@ body {
       @include inline-block();
       margin-top: 10px;
     }
+  }
+}
+
+#app-footer .language-box
+{
+  margin: 20px;
+  margin-bottom: 0px;
+
+  ul
+  {
+    margin-bottom: 0px;
+  }
+
+  li
+  {
+    @include inline-block();
   }
 }
 

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,5 +1,7 @@
 class AboutController < ApplicationController
   respond_to :html, :json
+  include CurrentLanguage
+  before_action :set_current_lang
 
   def index
     # Send an email based on the contents of the feedback form when submitted.

--- a/app/controllers/concerns/current_language.rb
+++ b/app/controllers/concerns/current_language.rb
@@ -3,4 +3,8 @@ module CurrentLanguage
     return 'en' if cookies[:googtrans].nil?
     cookies[:googtrans].split('/').last
   end
+
+  def set_current_lang
+    @current_lang = current_language
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,4 @@
 class HomeController < ApplicationController
   include CurrentLanguage
-
-  def index
-    @current_lang = current_language
-  end
+  before_action :set_current_lang
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,6 +1,7 @@
 class LocationsController < ApplicationController
-  include CurrentLanguage
   include Cacheable
+  include CurrentLanguage
+  before_action :set_current_lang
 
   def index
     translator = KeywordTranslator.new(

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,7 +1,7 @@
 - title ''
 %section#search-container
   %section#search-top-utilities.search-utilities
-    = render 'component/search/languages'
+    = render 'shared/languages'
   = render 'component/search/box'
   %section#search-bottom-utilities.search-utilities
 = render 'homepage_links'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
   %head
     = render 'shared/head'
 
-  %body{class: "#{controller_name == 'home' ? '' : 'inside '}#{controller_name} #{action_name}"}
+  %body{ class: "#{controller_name == 'home' ? '' : 'inside '}#{controller_name} #{action_name}" }
     %section#content
       = render 'shared/alert'
       = render 'shared/header'

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -15,4 +15,5 @@
     for your city or
     #{link_to 'view project details', 'http://ohanapi.org'}.
 
+  = render 'shared/languages'
   #google-translate-container

--- a/app/views/shared/_languages.html.haml
+++ b/app/views/shared/_languages.html.haml
@@ -1,5 +1,5 @@
 - if SETTINGS[:language_links].present?
-  %section#language-box
+  %section.language-box
     %ul
       - SETTINGS[:language_links].each do |language_plus_code|
         %li

--- a/spec/features/general/translate_spec.rb
+++ b/spec/features/general/translate_spec.rb
@@ -21,7 +21,7 @@ feature 'page translation', :js do
         set_cookie('googtrans=/en/es; path=/; domain=.lvh.me')
 
       visit("http://www.lvh.me:#{Capybara.server_port}/")
-      within('#language-box') do
+      within('#search-top-utilities .language-box') do
         all_links = all('a')
         expect(all_links).not_to include 'Español'
       end
@@ -32,10 +32,10 @@ feature 'page translation', :js do
   context 'homepage is translated' do
     it 'displays translated contents' do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
-      find_link('Español').click
-      delay
-      expect(page.driver.cookies['googtrans']).to eq('/en/es')
-      within('#language-box') do
+      within('#search-top-utilities .language-box') do
+        find_link('Español').click
+        delay
+        expect(page.driver.cookies['googtrans']).to eq('/en/es')
         all_links = all('a')
         expect(all_links).not_to include 'Español'
       end
@@ -46,7 +46,7 @@ feature 'page translation', :js do
   context 'results page is translated', :vcr do
     it 'displays translated contents' do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
-      find_link('Español').click
+      find('#search-top-utilities .language-box').find_link('Español').click
       delay
       find(:css, '#button-search').click
       delay # give Google Translate a chance to translate page
@@ -57,15 +57,15 @@ feature 'page translation', :js do
   context 'page is translated between languages' do
     it 'displays translated content for each language' do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
-      find_link('Español').click
+      find('#search-top-utilities .language-box').find_link('Español').click
       delay
       expect(page.driver.cookies['googtrans']).to eq('/en/es')
       expect(page).to have_content('Necesito')
-      find_link('Tagalog').click
+      find('#search-top-utilities .language-box').find_link('Tagalog').click
       delay
       expect(page.driver.cookies['googtrans']).to eq('/en/tl')
       expect(page).to have_content('Kailangan ko')
-      find_link('English').click
+      find('#search-top-utilities .language-box').find_link('English').click
       expect(page).to have_content('I need')
       delay
       expect(page.driver.cookies['googtrans']).to eq('/en/en')

--- a/spec/features/pages/homepage_spec.rb
+++ b/spec/features/pages/homepage_spec.rb
@@ -22,7 +22,7 @@ describe 'Home page content elements' do
   end
 
   it 'includes english language status' do
-    expect(find('#language-box')).to have_content('English')
+    expect(find('#search-top-utilities .language-box')).to have_content('English')
   end
 
   it 'displays headers for the general links' do
@@ -73,6 +73,12 @@ describe 'Home page footer elements' do
     within('#app-footer') do
       expect(find_link('Get this app')[:href]).
         to eq('https://github.com/codeforamerica/ohana-web-search')
+    end
+  end
+
+  it 'includes english language status' do
+    within('#app-footer') do
+      expect(find('.language-box')).to have_content('English')
     end
   end
 end


### PR DESCRIPTION
Fixes #289 - Adds language links to the footer, primarily for the
inside pages so that primary languages don’t need to be hunted down inside the
Google Translate Widget.
