### PR TITLE
Removes unused module ref

### DIFF
--- a/app/assets/javascripts/routes/about/index.js
+++ b/app/assets/javascripts/routes/about/index.js
@@ -3,7 +3,7 @@ require([
   'app/feedback-form-manager',
   'application'
 ],
-function (gt, feedback) {
+function (feedback) {
   'use strict';
 
   // Initialize the feedback form.


### PR DESCRIPTION
Fixes issue of unused module ref making `feedback` variable undefined
on /about page.
