### PR TITLE
Remove alert link underline

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -37,6 +37,7 @@
     {
       color:$white;
       border-bottom:1px solid rgba($white,.5);
+      text-decoration: none;
     }
 
     a:hover


### PR DESCRIPTION
There is a double-underline when links appear in the alert. This
removes the default underline.
