### PR TITLE
Fixes #573 - Browser upgrade alert

### DIFF
--- a/app/assets/javascripts/app/alert-manager.js
+++ b/app/assets/javascripts/app/alert-manager.js
@@ -6,6 +6,9 @@ define(
 function () {
   'use strict';
 
+  // The events the alert broadcasts.
+  var _events = {};
+
   // HTML element for the alert container.
   var _alertContainer;
 
@@ -59,6 +62,7 @@ function () {
 
   // Hiding the alert box clears its content and hides it using CSS.
   function hide() {
+    _broadcastEvent('close');
     _alertContainer.classList.add('hide');
     _content.innerHTML = '';
   }
@@ -68,10 +72,24 @@ function () {
     hide();
   }
 
+  // @param evt [String] The type of event to broadcast.
+  // Supports 'close'.
+  function _broadcastEvent(evt) {
+    if (_events[evt])
+      _events[evt].call();
+  }
+
+  // @param event [String] The event name to listen for. Supports 'close'.
+  // @param callback [Function] The function called when the event has fired.
+  function addEventListener(event, callback) {
+    _events[event] = callback;
+  }
+
   return {
     init:init,
     show:show,
     hide:hide,
-    type:type
+    type:type,
+    addEventListener:addEventListener
   };
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -70,10 +70,15 @@
 //
 require([
   'util/translation/google-translate-manager',
+  'util/browser-upgrade-notice',
   'domReady!'
 ],
-function (googleTranslate) {
+function (googleTranslate, browserUpgradeNotice) {
   'use strict';
+
+  // Show a browser upgrade notice on IE8 and below.
+  if (document.documentElement.classList.contains('lt-ie9'))
+    browserUpgradeNotice.show();
 
   // The Google translate manager handles loading of the
   // Google Website Translator Gadget at the bottom of the page's body.

--- a/app/assets/javascripts/util/browser-upgrade-notice.js
+++ b/app/assets/javascripts/util/browser-upgrade-notice.js
@@ -1,0 +1,31 @@
+// Provides a upgrade notice that can be shown to outdated browsers (e.g. IE8).
+define([
+  'util/cookie',
+  'app/alert-manager'
+],
+function (cookie, alert) {
+  'use strict';
+
+  // Show upgrade notice if browser-upgrade-notice cookie isn't set.
+  function show() {
+    if (cookie.read('browser-upgrade-notice') === null) {
+      var notice = "<i class='fa fa-exclamation-triangle'></i> " +
+                   'Your browser is out-of-date and has known security issues.' +
+                   '<br />' +
+                   "<a href='https://browser-update.org/update.html'>" +
+                   'Please visit this page to download an up-to-date browser.' +
+                   '</a>';
+      alert.addEventListener('close', _alertClosed);
+      alert.show(notice, alert.type.INFO);
+    }
+  }
+
+  // Create a cookie when the alert is closed that will hide the alert for the next day.
+  function _alertClosed() {
+    cookie.create('browser-upgrade-notice', 'true', true, 1);
+  }
+
+  return {
+    show:show
+  };
+});

--- a/app/assets/javascripts/util/cookie.js.erb
+++ b/app/assets/javascripts/util/cookie.js.erb
@@ -1,0 +1,52 @@
+// Cookie CRUD functions, from http://www.quirksmode.org/js/cookies.html
+// ERB needed to retrieve domain name that the cookie is saved under.
+define(
+function () {
+  'use strict';
+
+  // @param name [String] The cookie's name.
+  // @param value [String] The cookie's value.
+  // @param useDomain [Boolean] Whether set under subdomains or not.
+  // @param days [Number] Number of days till the cookie expires.
+  // Can be negative.
+ function create(name, value, useDomain, days) {
+    if (days) {
+      var date = new Date();
+      date.setTime(date.getTime() + (days*24*60*60*1000));
+      var expires = '; expires=' + date.toGMTString();
+    }
+    else var expires = '';
+
+    var setting = name + '=' + value + expires + '; path=/';
+
+    // Sets the cookie under domain and subdomains (if useDomain parameter is present).
+    document.cookie = setting;
+    if (useDomain)
+      document.cookie = setting + "; domain=.<%= ENV['DOMAIN_NAME'] %>";
+  }
+
+  // @param name [String] The cookie's name to read.
+  // @return [String] The named cookie's value, or null.
+  function read(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for(var i=0;i < ca.length;i++) {
+      var c = ca[i];
+      while (c.charAt(0)==' ') c = c.substring(1,c.length);
+      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+    }
+    return null;
+  }
+
+  // @param name [String] The cookie's name to remove.
+  // @param usedDomain [Boolean] Whether to clear subdomains also.
+  function erase(name, useDomain) {
+    create(name, '', !!useDomain, -1);
+  }
+
+  return {
+    create:create,
+    read:read,
+    erase:erase
+  };
+});


### PR DESCRIPTION
- Fixes #573 - Displays dismissible upgrade alert for visitors that visit
  with IE8. URL given in alert is https://browser-update.org/update.html.
  Sets a cookie after alert is closed so alert isn’t displayed again the
  same day. Cookie expires after 1 day.
- Implements addEventListener on alert component so observers can
  respond to closing of the alert box.
