### PR TITLE
Fixes #551 - remove gsub in requirejs tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,3 +17,5 @@
 
     - if Rails.env.production? && ENV['GOOGLE_ANALYTICS_ID'].present?
       = render 'shared/google_analytics/event_tracking'
+
+    = requirejs_include_tag("routes/#{controller_name}/#{action_name}")

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -15,7 +15,4 @@
     for your city or
     #{link_to 'view project details', 'http://ohanapi.org'}.
 
-  -# This line needs to go ABOVE the Google Translate code, or it can take too long to load (see issue #462)
-  = requirejs_include_tag("routes/#{controller_name}/#{action_name}").gsub("/assets/routes/#{controller_name}/#{action_name}", "routes/#{controller_name}/#{action_name}").html_safe
-
   #google-translate-container


### PR DESCRIPTION
- Fixes #551 - removes gsub in requires tag.
- Also, moves requirejs tag outside of footer element.
