### PR TITLE
Fixes 517 - makes zip code on results search term

### DIFF
--- a/app/views/component/detail/_address.html.haml
+++ b/app/views/component/detail/_address.html.haml
@@ -16,4 +16,4 @@
     = location.address.state
 
   %span.zipcode{ itemprop: 'postalCode' }
-    = location.address.zip
+    = link_to location.address.zip, locations_path(location: location.address.zip)

--- a/app/views/component/detail/_mail_address.html.haml
+++ b/app/views/component/detail/_mail_address.html.haml
@@ -17,4 +17,4 @@
     = location.mail_address.state
 
   %span.zipcode{ itemprop: 'postalCode' }
-    = location.mail_address.zip
+    = link_to location.mail_address.zip, locations_path(location: location.mail_address.zip)

--- a/spec/cassettes/clicking_search_links_from_details_page/when_clicking_ZIP_code_link_in_location_address/displays_locations_that_are_nearby_to_that_ZIP_code.yml
+++ b/spec/cassettes/clicking_search_links_from_details_page/when_clicking_ZIP_code_link_in_location_address/displays_locations_that_are_nearby_to_that_ZIP_code.yml
@@ -1,0 +1,184 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 11 Sep 2014 18:19:43 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - b012b563-b98c-4003-9af6-ccd44e5068c9
+      X-Runtime:
+      - '0.046708'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"id":22,"accessibility":["Disabled Parking","Disabled Restroom","Wheelchair"],"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"hours":"Monday-Friday,
+        8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese (Cantonese)","Chinese
+        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"email":"suzanne@example.com","extension":"x1200","fax":"202-555-1212","id":29,"name":"Suzanne
+        Badenhoop","phone":"123-456-7890","title":"Board President"}],"faxes":[{"id":21,"number":"650
+        627-8244","department":null}],"mail_address":{"id":21,"attention":"Hella Fellas","street":"2013
+        Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}],"services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"bazfoo","service_areas":["San Mateo County","Alameda County","Contra
+        Costa County","Marin County","San Francisco County","Santa Clara County"],"short_desc":null,"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00","categories":[]},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"short_desc":null,"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00","categories":[]}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"}}'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:19:43 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=05201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Current-Page:
+      - '1'
+      Date:
+      - Thu, 11 Sep 2014 18:19:43 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 8f055dda-1955-4623-9415-7fa6e80b9c49
+      X-Runtime:
+      - '0.111849'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":22,"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/contacts","faxes_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/faxes","services_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/services","url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:19:43 GMT
+recorded_with: VCR 2.9.2

--- a/spec/cassettes/clicking_search_links_from_details_page/when_clicking_ZIP_code_link_in_location_mailing_address/displays_locations_that_are_nearby_to_that_ZIP_code.yml
+++ b/spec/cassettes/clicking_search_links_from_details_page/when_clicking_ZIP_code_link_in_location_mailing_address/displays_locations_that_are_nearby_to_that_ZIP_code.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 11 Sep 2014 18:19:42 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - c2c84197-c87a-44ca-9afe-b4430f538482
+      X-Runtime:
+      - '0.039433'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"id":22,"accessibility":["Disabled Parking","Disabled Restroom","Wheelchair"],"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"hours":"Monday-Friday,
+        8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese (Cantonese)","Chinese
+        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"email":"suzanne@example.com","extension":"x1200","fax":"202-555-1212","id":29,"name":"Suzanne
+        Badenhoop","phone":"123-456-7890","title":"Board President"}],"faxes":[{"id":21,"number":"650
+        627-8244","department":null}],"mail_address":{"id":21,"attention":"Hella Fellas","street":"2013
+        Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}],"services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"bazfoo","service_areas":["San Mateo County","Alameda County","Contra
+        Costa County","Marin County","San Francisco County","Santa Clara County"],"short_desc":null,"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00","categories":[]},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"short_desc":null,"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00","categories":[]}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"}}'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:19:42 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=90210
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?keyword=&location=90210&page=0>;
+        rel="last"
+      X-Total-Count:
+      - '0'
+      X-Total-Pages:
+      - '0'
+      Date:
+      - Thu, 11 Sep 2014 18:19:43 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 2a1eb147-3060-43f5-94aa-d6ec9654c31a
+      X-Runtime:
+      - '0.099481'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:19:43 GMT
+recorded_with: VCR 2.9.2

--- a/spec/cassettes/clicking_search_links_from_details_page/when_clicking_organization_link_in_location_detail_view/displays_locations_that_belong_to_that_organization.yml
+++ b/spec/cassettes/clicking_search_links_from_details_page/when_clicking_organization_link_in_location_detail_view/displays_locations_that_belong_to_that_organization.yml
@@ -1,0 +1,184 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 11 Sep 2014 18:19:41 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 8d09ee85-fd0a-4354-a6ba-60a90d96aab5
+      X-Runtime:
+      - '0.040714'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"id":22,"accessibility":["Disabled Parking","Disabled Restroom","Wheelchair"],"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"hours":"Monday-Friday,
+        8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese (Cantonese)","Chinese
+        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"email":"suzanne@example.com","extension":"x1200","fax":"202-555-1212","id":29,"name":"Suzanne
+        Badenhoop","phone":"123-456-7890","title":"Board President"}],"faxes":[{"id":21,"number":"650
+        627-8244","department":null}],"mail_address":{"id":21,"attention":"Hella Fellas","street":"2013
+        Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}],"services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"bazfoo","service_areas":["San Mateo County","Alameda County","Contra
+        Costa County","Marin County","San Francisco County","Santa Clara County"],"short_desc":null,"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00","categories":[]},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"short_desc":null,"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00","categories":[]}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"}}'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:19:41 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&org_name=SanMaceo%20Example%20Agency.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Current-Page:
+      - '1'
+      Date:
+      - Thu, 11 Sep 2014 18:19:41 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 6627a2bd-c861-47c5-95f1-5d8a98eac46a
+      X-Runtime:
+      - '0.027484'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":22,"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/contacts","faxes_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/faxes","services_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/services","url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:19:42 GMT
+recorded_with: VCR 2.9.2

--- a/spec/cassettes/searching_from_details_page/when_clicking_organization_link_in_results/displays_locations_that_belong_to_that_organization.yml
+++ b/spec/cassettes/searching_from_details_page/when_clicking_organization_link_in_results/displays_locations_that_belong_to_that_organization.yml
@@ -1,0 +1,184 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 11 Sep 2014 18:09:35 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - de270aa3-5462-4c9e-8aef-9b9578da9621
+      X-Runtime:
+      - '0.039291'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"id":22,"accessibility":["Disabled Parking","Disabled Restroom","Wheelchair"],"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","emails":["sanmaceo@co.sanmaceo.ca.us","maceo@parker.com"],"hours":"Monday-Friday,
+        8-5; Saturday, 10-6; Sunday 11-5","languages":["Chinese (Cantonese)","Chinese
+        (Taiwanese)","Filipino (Tagalog)","Russian","Spanish"],"latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","transportation":"SAMTRANS
+        stops within 1 block","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"contacts":[{"email":"suzanne@example.com","extension":"x1200","fax":"202-555-1212","id":29,"name":"Suzanne
+        Badenhoop","phone":"123-456-7890","title":"Board President"}],"faxes":[{"id":21,"number":"650
+        627-8244","department":null}],"mail_address":{"id":21,"attention":"Hella Fellas","street":"2013
+        Avenue of the fellows, Suite 100","city":"San Maceo","state":"VT","zip":"90210"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}],"services":[{"id":22,"audience":"Profit
+        and nonprofit businesses, the public, military facilities, schools and government
+        entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS IS FOR
+        TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"bazfoo","service_areas":["San Mateo County","Alameda County","Contra
+        Costa County","Marin County","San Francisco County","Santa Clara County"],"short_desc":null,"urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.791-07:00","categories":[]},{"id":23,"audience":"Second
+        service and nonprofit businesses, the public, military facilities, schools
+        and government entities","description":"[NOTE THIS IS NOT A REAL ORGANIZATION--THIS
+        IS FOR TESTTING PURPOSES OF THIS ALPHA APP] Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Praesent suscipit metus eu orci lobortis dictum. In hac habitasse
+        platea dictumst. Vivamus vulputate, neque ut sodales gravida, lorem nunc pharetra
+        ligula, ac cursus sem justo a sapien. Duis vitae vestibulum magna. Sed vel
+        augue in justo rhoncus viverra. Nam ac felis a purus lobortis porttitor sit
+        amet quis est. Suspendisse vulputate nisl quis nisi fermentum aliquet euismod
+        at augue. Sed ultricies, purus dapibus tristique dictum, tortor mauris porttitor
+        nulla, at porta nisl sem sed dolor. Proin ac hendrerit erat. Duis porta iaculis
+        orci, eu euismod quam tristique in. Phasellus nec purus sit amet sapien volutpat
+        egestas.","eligibility":"None","fees":"None, except for permits and photocopying.
+        Cash, checks and credit cards accepted","funding_sources":["City","County","Federal","State"],"how_to_apply":"Walk
+        in or apply by phone or mail","keywords":["Ruby on Rails/MongoDB/Redis","FIFA
+        World Cup"],"name":"hasdfasf","service_areas":["San Mateo County","Alameda
+        County","Contra Costa County","Marin County","San Francisco County","Santa
+        Clara County"],"short_desc":null,"urls":["http://www.example.com","http://www.example2.com"],"wait":"No
+        wait to 2 weeks","updated_at":"2014-04-18T12:49:47.850-07:00","categories":[]}],"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"}}'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:09:35 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&org_name=SanMaceo%20Example%20Agency.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Total-Count:
+      - '1'
+      X-Total-Pages:
+      - '1'
+      X-Current-Page:
+      - '1'
+      Date:
+      - Thu, 11 Sep 2014 18:09:35 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 6f7c9f09-9203-4a23-86be-93ec540a5294
+      X-Runtime:
+      - '0.026003'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":22,"admin_emails":["foo@bar.com"],"coordinates":[-73.1968254,42.878036],"description":"[NOTE
+        THIS IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA
+        APP] Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","latitude":42.878036,"longitude":-73.1968254,"name":"San
+        Maceo Agency","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"san-maceo-agency","updated_at":"2014-08-02T20:51:59.592-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/contacts","faxes_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/faxes","services_url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency/services","url":"http://ohana-api-test.herokuapp.com/api/locations/san-maceo-agency","address":{"id":21,"street":"2013
+        Avenue of the fellows, Suite 100","city":"Burlington","state":"VT","zip":"05201"},"organization":{"id":8,"name":"SanMaceo
+        Example Agency.","slug":"sanmaceo-example-agency","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/sanmaceo-example-agency/locations"},"phones":[{"id":21,"department":"Information","extension":null,"number":"650
+        372-6200","number_type":"TTY","vanity_number":null},{"id":22,"department":"Reservations","extension":null,"number":"650
+        372-6200","number_type":null,"vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 18:09:35 GMT
+recorded_with: VCR 2.9.2

--- a/spec/cassettes/searching_from_results_page/when_clicking_ZIP_code_link_in_results/displays_locations_that_are_nearby_to_that_ZIP_code.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_ZIP_code_link_in_results/displays_locations_that_are_nearby_to_that_ZIP_code.yml
@@ -1,0 +1,238 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?keyword=&page=24>; rel="last",
+        <http://ohana-api-test.herokuapp.com/api/search?keyword=&page=2>; rel="next"
+      X-Total-Count:
+      - '24'
+      X-Total-Pages:
+      - '24'
+      X-Current-Page:
+      - '1'
+      X-Next-Page:
+      - '2'
+      Date:
+      - Thu, 11 Sep 2014 17:57:48 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - c81b787f-9544-4c9b-9e06-ffc94d96a94f
+      X-Runtime:
+      - '0.034210'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":1,"admin_emails":[],"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.        Provides
+        case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish.  Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","latitude":37.477227,"longitude":-122.213221,"name":"Fair
+        Oaks Adult Activity Center","short_desc":"A multipurpose senior citizens''
+        center serving the Redwood City area.","slug":"fair-oaks-adult-activity-center","updated_at":"2014-05-09T20:49:18.836-07:00","urls":["http://www.peninsulafamilyservice.org"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center/contacts","faxes_url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center/faxes","services_url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center/services","url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center","address":{"id":1,"street":"2600
+        Middlefield Road","city":"Redwood City","state":"CA","zip":"94063"},"organization":{"id":1,"name":"Peninsula
+        Family Service","slug":"peninsula-family-service","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/peninsula-family-service","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/peninsula-family-service/locations"},"phones":[{"id":1,"department":null,"extension":null,"number":"650
+        780-7525","number_type":null,"vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 17:57:48 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=Samaritan%20House&location=&org_name=&utf8=%E2%9C%93
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?keyword=Samaritan+House&location=&org_name=&page=4&utf8=%E2%9C%93>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?keyword=Samaritan+House&location=&org_name=&page=2&utf8=%E2%9C%93>;
+        rel="next"
+      X-Total-Count:
+      - '4'
+      X-Total-Pages:
+      - '4'
+      X-Current-Page:
+      - '1'
+      X-Next-Page:
+      - '2'
+      Date:
+      - Thu, 11 Sep 2014 17:57:48 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 46c3e626-36ea-4a2d-b988-0fe600af9380
+      X-Runtime:
+      - '0.036077'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":18,"admin_emails":[],"coordinates":[-122.207057,37.468678],"description":"Provides
+        free medical care to those in need. Offers basic medical exams for adults
+        and tuberculosis screening. Assists the individual to access other services
+        in the community. By appointment only, Project Smile provides a free dental
+        exam, dental cleaning and oral hygiene instruction for children, age 3-12,
+        of Samaritan House clients.","latitude":37.468678,"longitude":-122.207057,"name":"Redwood
+        City Free Medical Clinic","short_desc":"Provides free medical care to those
+        in need.","slug":"redwood-city-free-medical-clinic","updated_at":"2014-07-15T13:20:11.599-07:00","urls":["http://www.samaritanhouse.com"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-free-medical-clinic/contacts","faxes_url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-free-medical-clinic/faxes","services_url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-free-medical-clinic/services","url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-free-medical-clinic","address":{"id":18,"street":"114
+        Fifth Avenue","city":"Redwood City","state":"CA","zip":"94063"},"organization":{"id":5,"name":"Samaritan
+        House","slug":"samaritan-house","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/samaritan-house","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/samaritan-house/locations"},"phones":[{"id":18,"department":null,"extension":null,"number":"650
+        839-1447","number_type":null,"vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 17:57:48 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94063
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?keyword=&location=94063&page=11>;
+        rel="last", <http://ohana-api-test.herokuapp.com/api/search?keyword=&location=94063&page=2>;
+        rel="next"
+      X-Total-Count:
+      - '11'
+      X-Total-Pages:
+      - '11'
+      X-Current-Page:
+      - '1'
+      X-Next-Page:
+      - '2'
+      Date:
+      - Thu, 11 Sep 2014 17:57:48 GMT
+      Cache-Control:
+      - max-age=0, public
+      X-Request-Id:
+      - 2f3ab9f4-f9dc-4ecc-b2c4-05df93edc526
+      X-Runtime:
+      - '0.095102'
+      X-Powered-By:
+      - Phusion Passenger 4.0.50
+      Server:
+      - nginx/1.6.1 + Phusion Passenger 4.0.50
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":14,"admin_emails":[],"coordinates":[-122.231539,37.49144],"description":"Provides
+        food, clothing, bus tokens and shelter to individuals and families in times
+        of crisis from the Redwood City Corps office and community centers throughout
+        the county.   Administers Project REACH (Relief for Energy Assistance through
+        Community Help) funds to prevent energy shut-off through a one-time payment.
+        Counseling and translation services (English/Spanish) are available either
+        on a walk-in basis or by appointment. Rental assistance with available funds.
+        Another office (described separately) is located at 409 South Spruce Avenue,
+        South San Francisco (650-266-4591).","latitude":37.49144,"longitude":-122.231539,"name":"Redwood
+        City Corps","short_desc":"Provides a variety of emergency services to low-income
+        persons. Also sponsors recreational and educational activities.","slug":"redwood-city-corps","updated_at":"2014-05-09T20:49:18.943-07:00","urls":["http://www.tsagoldenstate.org"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-corps/contacts","faxes_url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-corps/faxes","services_url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-corps/services","url":"http://ohana-api-test.herokuapp.com/api/locations/redwood-city-corps","address":{"id":14,"street":"660
+        Veterans Blvd.","city":"Redwood City","state":"CA","zip":"94063"},"organization":{"id":4,"name":"Salvation
+        Army","slug":"salvation-army","urls":[],"url":"http://ohana-api-test.herokuapp.com/api/organizations/salvation-army","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/salvation-army/locations"},"phones":[{"id":14,"department":null,"extension":null,"number":"650
+        368-4643","number_type":null,"vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Thu, 11 Sep 2014 17:57:48 GMT
+recorded_with: VCR 2.9.2

--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -9,8 +9,8 @@ feature 'location details' do
       expect(page).to have_content('Mailing Address')
       expect(page).to have_content('Physical Address')
       expect(page).to have_content('2013 Avenue of the fellows')
-      expect(page).to have_content('90210')
-      expect(page).to have_content('05201')
+      expect(page).to have_link('90210')
+      expect(page).to have_link('05201')
     end
   end
 

--- a/spec/features/search/details_page_search_spec.rb
+++ b/spec/features/search/details_page_search_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+feature 'clicking search links from details page', :vcr do
+
+  before { visit_test_location }
+
+  context 'when clicking organization link in location detail view' do
+    it 'displays locations that belong to that organization' do
+      first('#detail-info header').click_link('SanMaceo Example Agency.')
+      expect(page.find('#list-view')).to have_link('San Maceo Agency')
+    end
+  end
+
+  context 'when clicking ZIP code link in location address' do
+    it 'displays locations that are nearby to that ZIP code' do
+      first('#contact-info .address').click_link('05201')
+      expect(page.find('#list-view')).to have_link('San Maceo Agency')
+    end
+  end
+
+  context 'when clicking ZIP code link in location mailing address' do
+    it 'displays locations that are nearby to that ZIP code' do
+      first('#contact-info .mail-address').click_link('90210')
+      expect(page).to have_content('No results found.')
+    end
+  end
+end

--- a/spec/features/search/results_page_search_spec.rb
+++ b/spec/features/search/results_page_search_spec.rb
@@ -103,6 +103,14 @@ feature 'searching from results page', :vcr do
     end
   end
 
+  context 'when clicking ZIP code link in results' do
+    it 'displays locations that are nearby to that ZIP code' do
+      search(keyword: 'Samaritan House')
+      first('#list-view li').click_link('94063')
+      expect(page).to have_link('Redwood City Corps')
+    end
+  end
+
   context 'when a search parameter has no value' do
     it 'is not included in the page title' do
       visit('/locations?location=94403&keyword=')


### PR DESCRIPTION
- Fixes #517 - Makes zip code clickable for a location search on the
  search results and details views, aligning the behavior to how the
  organization link works on the search results and details views.
- Adds tests for searching by click on zip code on search results and
  details views.
- Adds test for organization link on details view.

@monfresh Ready for review 'n' merge. Thx!
