### PR TITLE
Set maxZoom property on both maps.

### DIFF
--- a/app/assets/javascripts/detail/detail-map-manager.js
+++ b/app/assets/javascripts/detail/detail-map-manager.js
@@ -45,7 +45,7 @@ function (markerManager, googleMaps) {
       var latLng = new google.maps.LatLng(lat, lng);
 
       var mapOptions = {
-        zoom: 16,
+        maxZoom: 16,
         center: latLng,
         scrollwheel: false,
         zoomControl: true,

--- a/app/assets/javascripts/result/result-map-manager.js
+++ b/app/assets/javascripts/result/result-map-manager.js
@@ -133,7 +133,7 @@ function (BitMask, markerManager, googleMaps) {
     ];
 
     var mapOptions = {
-      zoom: 15,
+      maxZoom: 16,
       scrollwheel: false,
       zoomControl: true,
       panControl: false,


### PR DESCRIPTION
Fixes issue where map can be zoomed so close that side streets, etc. are cropped out of view.

This was a problem when the search results maps had only one marker, like this:
http://ohana-web-search-demo.herokuapp.com/locations?utf8=%E2%9C%93&keyword=san+mateo+example+location&location=

I set it on the detail map for consistency, although I couldn't find a case where that map started out zoomed in too close.
