### PR TITLE
Hides language links till google translate loads

### DIFF
--- a/app/assets/javascripts/util/translation/google-translate-manager.js
+++ b/app/assets/javascripts/util/translation/google-translate-manager.js
@@ -70,6 +70,9 @@ function (util, cookie, DropDownLayout) {
     // Activate hooks to manipulate Google Website Translator Gadget through
     // the URL 'translate' parameter.
     _layout.activate();
+
+    // Show the language links used to set the 'translate' parameter.
+    _activateLanguageLinks();
   }
 
   // @return [Object] Return the inline Google Website Translator Gadget
@@ -92,6 +95,15 @@ function (util, cookie, DropDownLayout) {
         cookie.create('googtrans', newCookieValue, true);
         window.location.reload();
       }
+    }
+  }
+
+  // Show any language links that appear on the page.
+  function _activateLanguageLinks() {
+    var links = document.querySelectorAll('.link-translate');
+    var numLinks = links.length;
+    while( numLinks > 0 ) {
+      links[--numLinks].classList.remove('hide');
     }
   }
 

--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -601,7 +601,7 @@ body {
 .home .search-utilities {
   background: $search-bg; // IE fallback
   background: rgba($search-bg, 0.9);
-  min-height: 40px;
+  min-height: 44px;
   padding: 10px;
   padding-right: 25px;
   text-align: right;

--- a/app/helpers/language_links_helper.rb
+++ b/app/helpers/language_links_helper.rb
@@ -3,8 +3,8 @@ module LanguageLinksHelper
     language = language_plus_code.split(':').first
     code = language_plus_code.split(':').second.strip!
 
-    link_to_unless(@current_lang == code, language, "?translate=#{code}", lang: code, class: 'notranslate button-small') do |language_text|
-      content_tag(:a, language_text, lang: code, class: 'translate-active button-small')
+    link_to_unless(@current_lang == code, language, "?translate=#{code}", lang: code, class: 'notranslate button-small link-translate hide') do |language_text|
+      content_tag(:a, language_text, lang: code, class: 'translate-active button-small link-translate hide')
     end
   end
 end


### PR DESCRIPTION
- Hides the language links till Google Translate Gadget loads. If it
  doesn’t load for some reason the links are hidden.
- Adjusts min-height styles slightly as the non-language link utility
  area height was shorter than when the language links were present.
- Adds CSS classes to the language link helper to identify them and
  hide them initially.
