### PR TITLE
Embed environment variables outside of assets

### DIFF
--- a/app/assets/javascripts/util/cookie.js
+++ b/app/assets/javascripts/util/cookie.js
@@ -1,7 +1,9 @@
 // Cookie CRUD functions, from http://www.quirksmode.org/js/cookies.html
 // ERB needed to retrieve domain name that the cookie is saved under.
-define(
-function () {
+define([
+  'util/environmentVariables'
+],
+function (envVars) {
   'use strict';
 
   // @param name [String] The cookie's name.
@@ -19,11 +21,17 @@ function () {
 
     var setting = name + '=' + value + expires + '; path=/';
 
+    // Set the cookie without the domain parameter.
+    document.cookie = setting;
     // Sets the cookie under domain and subdomains
     // (if useDomain parameter is present).
-    document.cookie = setting;
-    if (useDomain)
-      document.cookie = setting + "; domain=.<%= ENV['DOMAIN_NAME'] %>";
+    if (useDomain) {
+      var domain = envVars.getValue('DOMAIN_NAME');
+      var domainSetting = setting + '; domain=' + domain;
+      var subdomainSetting = setting + '; domain=.' + domain;
+      document.cookie = domainSetting;
+      document.cookie = subdomainSetting;
+    }
   }
 
   // @param name [String] The cookie's name to read.

--- a/app/assets/javascripts/util/environmentVariables.js
+++ b/app/assets/javascripts/util/environmentVariables.js
@@ -1,0 +1,35 @@
+// Used for accessing key/value environment variables
+// that are embedded in the webpage.
+define(
+function () {
+  'use strict';
+
+  var _envVars = null;
+
+  function init(id) {
+    var envVars = document.getElementById(id);
+    if (!envVars)
+      throw new Error('HTML id for Environment Variables was not found!');
+
+    // Read environment variables JSON.
+    _envVars = JSON.parse(envVars.innerHTML);
+
+    // Remove the script element from the DOM.
+    envVars.parentNode.removeChild(envVars);
+  }
+
+  // @param key [String] The environment variable to look up.
+  // @return The value of the supplied environment variable.
+  function getValue(key) {
+    // Lazy initialize the environment variables with a default HTML ID.
+    if (_envVars === null)
+      init('environment-variables');
+
+    return _envVars[key];
+  }
+
+  return {
+    init:init,
+    getValue:getValue
+  };
+});

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,4 +18,6 @@
     - if Rails.env.production? && ENV['GOOGLE_ANALYTICS_ID'].present?
       = render 'shared/google_analytics/event_tracking'
 
+    = render 'shared/environment_variables'
+
     = requirejs_include_tag("routes/#{controller_name}/#{action_name}")

--- a/app/views/shared/_environment_variables.html.haml
+++ b/app/views/shared/_environment_variables.html.haml
@@ -1,0 +1,2 @@
+%script{id: 'environment-variables', type: 'application/json'}
+  = raw({ DOMAIN_NAME: "#{ENV['DOMAIN_NAME']}" }.to_json)


### PR DESCRIPTION
Moves environment variables that are accessed via asset ERB file to
instead be embedded in the webpage and retrieved at runtime.
