### PR TITLE
Fixes #589 - removes IE10 (x) default clear button

### DIFF
--- a/app/assets/stylesheets/_mixins.css.scss
+++ b/app/assets/stylesheets/_mixins.css.scss
@@ -71,6 +71,17 @@
   }
 }
 
+// Turns off proprietary default IE10 styling of search input fields.
+@mixin reset-input-ie() {
+  // Turns off (x) that's added to inputs when the input has the
+  // clearable class added—meaning it already has a custom clear button.
+  .clearable {
+    input[type=search]::-ms-clear {
+      display: none;
+    }
+  }
+}
+
 // These are classes that apply rounding to one or more corners.
 // The "except" set will square off (non-round) the corners specified.
 // They are intended for UI components that positioned adjacent to another

--- a/app/assets/stylesheets/components/_input-search.css.scss
+++ b/app/assets/stylesheets/components/_input-search.css.scss
@@ -5,8 +5,9 @@
 // Form input styles.
 
 // Search.
-// Reset webkit added styles.
+// Reset browser-specific added styles.
 @include reset-input-webkit();
+@include reset-input-ie();
 
 .input-search-small {
   @include input-placeholder(rgba($white, 0.6), italic);


### PR DESCRIPTION
Fixes #589 - removes IE10 (x) default clear button.
IE10 adds an (x) to input fields to clear their contents. Since some
fields have a custom (x) added through the .clearable class, this
removes the default (x) on those fields.
