### PR TITLE
Fixes #468 - top-aligns superscript text.

### DIFF
--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -81,6 +81,18 @@ textarea {
     resize: vertical;
 }
 
+// Align and size super/subscripted text.
+sup,
+sub {
+  vertical-align: baseline;
+  position: relative;
+  top: -0.4em;
+  font-size: 80%;
+}
+sub {
+  top: 0.4em;
+}
+
 /* ==========================================================================
    Chrome Frame prompt
    ========================================================================== */
@@ -178,10 +190,6 @@ footer a:hover {
       color: $menubutton-popup-hover-color;
     }
   }
-}
-
-sup {
-    font-size: 80%;
 }
 
 .drop-down-container {
@@ -1458,7 +1466,7 @@ body {
 
       -ms-word-break: break-all;
       word-break: break-all;
-      // Non standard for webkit.
+      // Non-standard for webkit.
       word-break: break-word;
 
       @include border-radius(0px 0px 0px 10px);
@@ -1579,10 +1587,10 @@ body {
     .phone-type {
       font-size: $font_size_90;
       color: $greyscale_midtone;
+    }
 
-      // Set line height equal to the height of the adjacent text.
-      line-height: $font_size_100;
-      vertical-align: text-top;
+    .phone-extension {
+      font-size: $font_size_95;
     }
   }
 

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -48,7 +48,7 @@
                       %span{ itemprop: 'telephone' }
                         = format_phone(phone.number)
                       - if phone.extension.present?
-                        %sup.phone-extension
+                        %span.phone-extension
                           = phone.extension
                       - if phone.number_type
                         %sup.phone-type
@@ -95,7 +95,7 @@
                       %span{ itemprop: 'telephone' }
                         = format_phone(contact.phone)
                       - if contact.extension.present?
-                        %sup.phone-extension
+                        %span.phone-extension
                           = contact.extension
 
               - if contact.fax.present?


### PR DESCRIPTION
Fixes #468 - top-aligns superscript text. Superscripted text was
aligned to the bottom of the surrounding text, this commit top aligns
it instead.

![screen shot 2014-10-06 at 7 04 43 pm](https://cloud.githubusercontent.com/assets/704760/4535059/504d9eba-4dad-11e4-9303-ab06dd420765.png)

![screen shot 2014-10-06 at 7 04 36 pm](https://cloud.githubusercontent.com/assets/704760/4535060/50515f5a-4dad-11e4-84c5-13ee49d6f85c.png)
