### PR TITLE
Adds sass partial documentation

### DIFF
--- a/app/assets/stylesheets/_mixins.css.scss
+++ b/app/assets/stylesheets/_mixins.css.scss
@@ -1,4 +1,4 @@
-// Mixins are custom functions that abbreviate generating CSS effects.
+// Mixins are custom functions that abbreviate generating CSS rules.
 // Type size mixin provides mapping from human-readable font sizing labeling
 // to base font size values.
 @mixin type-size($size) {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -34,25 +34,48 @@
 /* ==========================================================================
    Vendor imports
    ========================================================================== */
+
+// The font icons used throughout the app.
 @import "font-awesome";
 
 /* ==========================================================================
    Main app imports
    ========================================================================== */
+
+// Settings used for customizing values across the site, such as colors.
 @import "variables";
+
+// Custom functions are like mixins (see below) but they don't set CSS
+// properties directly.
 @import "functions";
+
+// Mixins are custom functions that abbreviate generating CSS rules.
 @import "mixins";
+
+// Effects are things like opacity, display, and position changes.
+// Anything that affects a component's appearance along a scale or
+// in a binary fashion.
 @import "effects";
+
+// Stand-alone UI elements such as buttons.
 @import "components/*";
+
+// General styles that bring the app together.
 @import "base";
 
 /* ==========================================================================
    Media type imports
    ========================================================================== */
+
+// Style overrides for handling different screen sizes using media queries.
 @import "responsive";
+
+// Style overrides for handling the app's display when printed.
 @import "print";
 
 /* ==========================================================================
    Browser-specific override imports
    ========================================================================== */
+
+// Style overrides for handling quirks in Internet Explorer 8.
 @import "ie8"


### PR DESCRIPTION
Adds documentation to imports of sass partials, so each sass file
doesn’t need to be opened to see what it’s for.
