### PR TITLE
Fixes #632 - fixes incorrectly nested paragraph

### DIFF
--- a/app/helpers/info_box_helper.rb
+++ b/app/helpers/info_box_helper.rb
@@ -50,7 +50,7 @@ module InfoBoxHelper
       concat(content_tag :dt, info_box['title'])
       concat(content_tag :dd, info_box['description'])
     end
-    return unless info_box['url'].present?
+    return html if info_box['url'].blank?
     html.concat(content_tag(:p) do
       link_to('More info...', info_box['url'], target: '_blank')
     end)


### PR DESCRIPTION
- Fixes #632 - fixes incorrectly nested paragraph. The paragraph
  element containing the “More info…” link was inside the definition list
  when it should be outside of it.
- Also adds some code comments for method parameters in the
  info_box_helper methods for use by the yard gem.
