### PR TITLE
Fixes #635 - Moves terminology infobox position

### DIFF
--- a/app/views/component/locations/results/_body.html.haml
+++ b/app/views/component/locations/results/_body.html.haml
@@ -1,14 +1,14 @@
 = render 'component/locations/results/header'
 %section#results-entries
+  - if @search.map_data.size != 0
+    = render 'component/locations/results/map_view'
+
   - if info_box_key_corresponding_to_keyword.present?
     %section#terminology-box-container
       .terminology-box
         = render_info_box(info_box_key_corresponding_to_keyword)
 
   - if @search.locations.present?
-    - if @search.map_data.size != 0
-      = render 'component/locations/results/map_view'
-
     = render 'component/locations/results/list_view'
   - else
     %section.no-results


### PR DESCRIPTION
Moves terminology info box position below map so that map isn’t
separated from the large/small map button.
