### PR TITLE
Updates Readme: Removes ruby version section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,5 @@ To see the actual tests, browse through the [spec](https://github.com/codeforame
 ## Contributing
 We'd love to get your help developing this project! Take a look at the [Contribution Document](https://github.com/codeforamerica/ohana-web-search/blob/master/CONTRIBUTING.md) to see how you can make a difference.
 
-## Supported Ruby Version
-This library aims to support and is [tested against](http://travis-ci.org/codeforamerica/ohana-web-search) Ruby version 2.1.2.
-
-If something doesn't work on this version, it should be considered a bug.
-
-This library may inadvertently work (or seem to work) on other Ruby implementations, however support will only be provided for the version above.
-
-If you would like this library to support another Ruby version, you may volunteer to be a maintainer. Being a maintainer entails making sure all tests run and pass on that implementation. When something breaks on your implementation, you will be personally responsible for providing patches in a timely fashion. If critical issues for a particular implementation exist at the time of a major release, support for that Ruby version may be dropped.
-
 ## Copyright
 Copyright (c) 2013-2014 Code for America. See [LICENSE](https://github.com/codeforamerica/ohana-web-search/blob/master/LICENSE.md) for details.


### PR DESCRIPTION
The Supported Ruby Version section has the ruby version used, which is
redundant to
https://github.com/codeforamerica/ohana-web-search#stack-overview. It
also provides advice on being a maintainer, but this should appear in
the contribution guidelines if it’s important to mention.
