### PR TITLE
Fixes #645 - removes inline print script

### DIFF
--- a/app/assets/javascripts/detail/detail-init.js
+++ b/app/assets/javascripts/detail/detail-init.js
@@ -1,14 +1,16 @@
 require([
   'detail/detail-map-manager',
   'detail/character-limited/character-limiter',
-  'search/header-manager'
+  'search/header-manager',
+  'detail/utility-links-manager'
 ],
-function (map, cl, header) {
+function (map, cl, header, utilityLinks) {
   'use strict';
 
   map.init();
   cl.init();
   header.init();
+  utilityLinks.init();
 
 },
 function (err) {
@@ -24,13 +26,15 @@ function (err) {
   require([
     'detail/no-detail-map-manager',
     'detail/character-limited/character-limiter',
-    'search/header-manager'
+    'search/header-manager',
+    'detail/utility-links-manager'
   ],
-  function (map,cl,header) {
+  function (map, cl, header, utilityLinks) {
 
     map.init();
     cl.init();
     header.init();
+    utilityLinks.init();
 
   });
 });

--- a/app/assets/javascripts/detail/utility-links-manager.js
+++ b/app/assets/javascripts/detail/utility-links-manager.js
@@ -1,0 +1,27 @@
+// Manages the utility links that appear on the details view.
+define(
+function () {
+  'use strict';
+
+  // The DOM element for the print button utility link.
+  var _printButton;
+
+  function init() {
+    _printButton = document.querySelector('.utility-links .button-print');
+
+    // Set event on print button and show the button.
+    _printButton.addEventListener('click', _clickPrintButton, false);
+    _printButton.classList.remove('hide');
+  }
+
+  // Issue print command when print button is clicked.
+  // @param evt [Object] The click event object.
+  function _clickPrintButton(evt) {
+    evt.preventDefault();
+    window.print();
+  }
+
+  return {
+    init:init
+  };
+});

--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -609,14 +609,14 @@ body {
   // back to search, directions, print
   .utility-links {
 
-    >span:first-child {
+    > span {
       border-left: 1px dotted $greyscale_light;
-    }
-
-    >span {
-      border-right: 1px dotted $greyscale_light;
       @include inline-block();
       vertical-align: baseline;
+    }
+
+    > span:last-child {
+      border-right: 1px dotted $greyscale_light;
     }
   }
 

--- a/app/views/component/locations/detail/_header_summary.html.haml
+++ b/app/views/component/locations/detail/_header_summary.html.haml
@@ -16,7 +16,7 @@
 
     %span.utility-links
       %span><
-        %a{ href: '#', class: 'button-utility button-print', onclick: 'window.print();return false;' }
+        %a.button-utility.button-print.hide{ href: '#' }
           %i{ class: 'fa fa-print' }
           Print
 


### PR DESCRIPTION
Fixes #645 - removes inline print script. With this commit the print
button won’t show up if/when JS is ever disabled.

Also moves utility link styles to apply the left-hand border by default and fill in the last utility link with a right-hand border, instead of the reverse, so that utility links can be selectively show/hidden from left-to-right and the styles won't break (e.g. a link won't lose a border).
