### PR TITLE
Adds assets partial

### DIFF
--- a/app/assets/stylesheets/_assets.css.scss.erb
+++ b/app/assets/stylesheets/_assets.css.scss.erb
@@ -1,0 +1,1 @@
+// Styles that use images from the asset pipeline.

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -60,6 +60,9 @@
 // Stand-alone UI elements such as buttons.
 @import "components/*";
 
+// Styles that use images from the asset pipeline (which needs to be an ERB).
+@import "assets";
+
 // General styles that bring the app together.
 @import "base";
 


### PR DESCRIPTION
Adds assets partial so asset pipeline assets can be contained in a
single ERB. Needed by forks such as smc-connect that use assets as
background images.
