### PR TITLE
Fixes #651 - turn off POI on details map

### DIFF
--- a/app/assets/javascripts/detail/detail-map-manager.js
+++ b/app/assets/javascripts/detail/detail-map-manager.js
@@ -32,6 +32,18 @@ function (markerManager, googleMaps) {
 
       var latLng = new google.maps.LatLng(lat, lng);
 
+      // Turns off Google Points-Of-Interest (POI) markers so the user
+      // doesn't click a POI and get an infowindow popped up.
+      var poiStyles =[
+        {
+          featureType: 'poi',
+          elementType: 'labels',
+          stylers: [
+            { visibility: 'off' }
+          ]
+        }
+      ];
+
       var mapOptions = {
         maxZoom: 16,
         center: latLng,
@@ -45,7 +57,8 @@ function (markerManager, googleMaps) {
         },
 
         mapTypeControl: false,
-        mapTypeId: google.maps.MapTypeId.ROADMAP
+        mapTypeId: google.maps.MapTypeId.ROADMAP,
+        styles: poiStyles
       };
       var map = new google.maps.Map(mapCanvas, mapOptions);
 


### PR DESCRIPTION
Fixes #651 - turn off default clickable points-of-interest locations
that Google adds on details map. This makes the map behavior consistent
with the search results map.
