### PR TITLE
Fixes #664 - adds phone extension to search result

### DIFF
--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -865,6 +865,10 @@ body {
         @include inline-block();
         margin-right: 10px;
       }
+
+      .phone-extension {
+        font-size: $font_size_95;
+      }
     }
 
     .kind {

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -24,6 +24,12 @@
                 %i{ class: 'fa fa-phone-square' }
                 %span{ itemprop: 'telephone' }
                   = format_phone(location.phones.first.number)
+                - if location.phones.first.extension.present?
+                  %span.phone-extension
+                    %span.delimiter
+                      = SETTINGS[:phone_extension_delimiter]
+                    %span.extension
+                      = location.phones.first.extension
 
           - if location.address.present?
             %p.address

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_extension.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_extension.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 27 Oct 2014 03:42:17 GMT
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Link:
+      - <http://ohana-api-test.herokuapp.com/api/search?keyword=&page=22>; rel="last",
+        <http://ohana-api-test.herokuapp.com/api/search?keyword=&page=2>; rel="next"
+      X-Total-Count:
+      - '22'
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - max-age=0, public
+      Etag:
+      - '"cc235fc33c6b5cb583b6101e20f04777"'
+      X-Request-Id:
+      - 24e0ba6f-b12e-4755-a20b-9344f5b2311f
+      X-Runtime:
+      - '0.040702'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":1,"active":true,"admin_emails":[],"alternate_name":null,"coordinates":[-122.213221,37.477227],"description":"A
+        walk-in center for older adults that provides social services, wellness, recreational,
+        educational and creative activities including arts and crafts, computer classes
+        and gardening classes. Coffee and healthy breakfasts are available daily.
+        A hot lunch is served Tuesday-Friday for persons age 60 or over and spouse.
+        Provides case management (including in-home assessments) and bilingual information
+        and referral about community services to persons age 60 or over on questions
+        of housing, employment, household help, recreation and social activities,
+        home delivered meals, health and counseling services and services to shut-ins.
+        Health insurance and legal counseling is available by appointment. Lectures
+        on a variety of health and fitness topics are held monthly in both English
+        and Spanish. Provides a variety of physical fitness opportunities, including
+        a garden club, yoga, tai chi, soul line dance and aerobics classes geared
+        toward older adults. Also provides free monthly blood pressure screenings,
+        quarterly blood glucose monitoring and health screenings by a visiting nurse.
+        Offers a Brown Bag Program in which low-income seniors can receive a bag of
+        groceries each week for a membership fee of $10 a year. Offers Spanish lessons.
+        Formerly known as Peninsula Family Service, Fair Oaks Intergenerational Center.
+        Formerly known as the Fair Oaks Senior Center. Formerly known as Family Service
+        Agency of San Mateo County, Fair Oaks Intergenerational Center.","latitude":37.477227,"longitude":-122.213221,"name":"Fair
+        Oaks Adult Activity Center","short_desc":"A multipurpose senior citizens''
+        center serving the Redwood City area.","slug":"fair-oaks-adult-activity-center","updated_at":"2014-10-23T11:51:49.298-07:00","urls":["http://www.peninsulafamilyservice.org"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center/contacts","services_url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center/services","url":"http://ohana-api-test.herokuapp.com/api/locations/fair-oaks-adult-activity-center","address":{"id":1,"street_1":"2600
+        Middlefield Road","street_2":null,"city":"Redwood City","state":"CA","postal_code":"94063"},"organization":{"id":1,"alternate_name":null,"date_incorporated":null,"description":"Peninsula
+        Family Service strengthens the community by providing children, families,
+        and older adults the support and tools to realize their full potential and
+        lead healthy, stable lives.","email":null,"name":"Peninsula Family Service","slug":"peninsula-family-service","website":null,"url":"http://ohana-api-test.herokuapp.com/api/organizations/peninsula-family-service","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/peninsula-family-service/locations"},"phones":[{"id":1,"department":null,"extension":null,"number":"650
+        780-7525","number_type":"voice","vanity_number":null},{"id":2,"department":null,"extension":null,"number":"650
+        701-0856","number_type":"fax","vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Mon, 27 Oct 2014 03:42:17 GMT
+- request:
+    method: get
+    uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.ohanapi-v1+json
+      User-Agent:
+      - Ohanakapa Ruby Gem 1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 27 Oct 2014 03:42:17 GMT
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Total-Count:
+      - '1'
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - max-age=0, public
+      Etag:
+      - '"b23c517bdf52aafd138664210e0bc4d2"'
+      X-Request-Id:
+      - 1303402b-d840-4c3f-b9b8-b18ca05718c0
+      X-Runtime:
+      - '0.040109'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":22,"active":true,"admin_emails":["foo@bar.com"],"alternate_name":"The
+        Test Spot","coordinates":[-122.4099154,37.7726402],"description":"[NOTE THIS
+        IS NOT A REAL ORGANIZATION--THIS IS FOR TESTTING PURPOSES OF THIS ALPHA APP]
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit
+        metus eu orci lobortis dictum. In hac habitasse platea dictumst. Vivamus vulputate,
+        neque ut sodales gravida, lorem nunc pharetra ligula, ac cursus sem justo
+        a sapien. Duis vitae vestibulum magna. Sed vel augue in justo rhoncus viverra.
+        Nam ac felis a purus lobortis porttitor sit amet quis est. Suspendisse vulputate
+        nisl quis nisi fermentum aliquet euismod at augue. Sed ultricies, purus dapibus
+        tristique dictum, tortor mauris porttitor nulla, at porta nisl sem sed dolor.
+        Proin ac hendrerit erat. Duis porta iaculis orci, eu euismod quam tristique
+        in. Phasellus nec purus sit amet sapien volutpat egestas.","latitude":37.7726402,"longitude":-122.4099154,"name":"Example
+        Location","short_desc":"[NOTE THIS IS NOT A REAL ENTRY--THIS IS FOR TESTING
+        PURPOSES OF THIS ALPHA APP]","slug":"example-location","updated_at":"2014-10-23T11:52:02.135-07:00","urls":["http://www.smchealth.org","http://www.example.com","http://www.example2.com"],"contacts_url":"http://ohana-api-test.herokuapp.com/api/locations/example-location/contacts","services_url":"http://ohana-api-test.herokuapp.com/api/locations/example-location/services","url":"http://ohana-api-test.herokuapp.com/api/locations/example-location","address":{"id":21,"street_1":"2013
+        Avenue of the fellows","street_2":"Suite 100","city":"San Francisco","state":"CA","postal_code":"94103"},"organization":{"id":8,"alternate_name":"Alternate
+        Agency Name","date_incorporated":"1970-01-01","description":"Sample organization
+        description. The Public Library inspires learning through innovative and visionary
+        programming and services—literacy programs, support for school success, access
+        to technology, safe, inviting spaces for youth and families, and gathering
+        places that connect the members of the community with a love of reading and
+        learning.","email":"info@example.org","name":"Example Agency","slug":"example-agency","website":"http://example.org","url":"http://ohana-api-test.herokuapp.com/api/organizations/example-agency","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/example-agency/locations"},"phones":[{"id":43,"department":"Information","extension":"123","number":"650
+        372-6200","number_type":"voice","vanity_number":"222-555-INFO"},{"id":44,"department":"Reservations","extension":null,"number":"650
+        627-8244","number_type":"fax","vanity_number":null},{"id":45,"department":"Hotline","extension":null,"number":"800
+        372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
+        Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
+    http_version: 
+  recorded_at: Mon, 27 Oct 2014 03:42:17 GMT
+recorded_with: VCR 2.9.2

--- a/spec/features/search/results_page_search_spec.rb
+++ b/spec/features/search/results_page_search_spec.rb
@@ -22,6 +22,10 @@ feature 'searching from results page', :vcr do
       expect(page).to have_content('(650) 372-6200')
     end
 
+    it 'displays the location phone extension' do
+      expect(page).to have_content('x 123')
+    end
+
     it 'displays the location address' do
       expect(page).to have_content('2013 Avenue of the fellows')
     end


### PR DESCRIPTION
Fixes #664 - adds phone extension to search results. Phone numbers
displayed on the search results list didn’t include a phone extension,
this commit adds them to the result list entries.
