### PR TITLE
Updates ffi to 1.9.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development do
 
   gem 'spring'
   gem 'spring-commands-rspec'
+  # listen is required by spring to turn on event-based file system listening.
   gem 'listen', '~> 1.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (0.4.2)
       faraday (~> 0.8)
-    ffi (1.9.3)
+    ffi (1.9.6)
     figaro (1.0.0)
       thor (~> 0.14)
     font-awesome-rails (4.2.0.0)


### PR DESCRIPTION
- Updates listen gem ffi gem sub-dependency to 1.9.6 from 1.9.3. Spring
  uses listen but does not currently support version 2.x.
- Adds code comment to gemfile noting why listen gem is present.
