### PR TITLE
Update chunky_png to 1.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    chunky_png (1.3.1)
+    chunky_png (1.3.3)
     cliver (0.3.2)
     coderay (1.1.0)
     compass (0.12.7)


### PR DESCRIPTION
chunky_png is used by compass-rails.

@monfresh ready for merge!
