### PR TITLE
Fixes #686 - makes short desc optional

### DIFF
--- a/app/views/component/detail/_location_short_desc.html.haml
+++ b/app/views/component/detail/_location_short_desc.html.haml
@@ -1,3 +1,4 @@
-%section{ class: 'short-desc' }
-  %span
-    = location.short_desc
+- if location.short_desc.present?
+  %section.short-desc
+    %span
+      = location.short_desc


### PR DESCRIPTION
Fixes #686 - short description was assumed to be present, however, it
is no longer necessarily present. This commit makes the short
description partial content only present when `short_desc` has a value.
