### PR TITLE
Updates translate spec search term

### DIFF
--- a/spec/features/general/translate_spec.rb
+++ b/spec/features/general/translate_spec.rb
@@ -42,7 +42,7 @@ feature 'page translation', :js do
       delay
       find(:css, '#button-search').click
       delay # give Google Translate a chance to translate page
-      expect(page).to have_content('Encontrar') # 'Encontrar' = 'Find'
+      expect(page).to have_content('Encuentre') # 'Encuentre' = 'Find'
     end
   end
 


### PR DESCRIPTION
- Search term “Find” is now being translated to “Encuentre,” not
  “Encontrar.” This commit updates the translate spec to search for
  “Encuentre.”
