### PR TITLE
Updates spring to 1.2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,8 +71,8 @@ group :development do
 
   gem 'spring'
   gem 'spring-commands-rspec'
-  # listen is required by spring to turn on event-based file system listening.
-  gem 'listen', '~> 1.0'
+  # Required by spring to turn on event-based file system listening.
+  gem 'spring-watcher-listen'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,9 +236,12 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    spring (1.1.3)
+    spring (1.2.0)
     spring-commands-rspec (1.0.2)
       spring (>= 0.9.1)
+    spring-watcher-listen (1.0.0)
+      listen (~> 1.0)
+      spring (~> 1.2)
     sprockets (2.11.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -295,7 +298,6 @@ DEPENDENCIES
   kaminari
   kgio
   letter_opener (~> 1.2.0)
-  listen (~> 1.0)
   memcachier
   ohanakapa (~> 1.1.1)
   poltergeist
@@ -310,6 +312,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   spring
   spring-commands-rspec
+  spring-watcher-listen
   uglifier
   unicorn
   vcr (~> 2.9.0)


### PR DESCRIPTION
- Updates spring to 1.2.0. This version moves the `listen` dependency
  to the `spring-watcher-listen` gem, so that gem replaces the `listen`
  gem in this commit as well.
