### PR TITLE
Use Etag based on git commit to invalidate cache.

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -72,47 +72,6 @@ Once your site is serving your own data from your own instance of Ohana API, and
 ```
 
 ## Caching
-Depending on how many visitors your app gets, you might want to improve the performance of the app by configuring two types of caching: one is caching the API requests via `Faraday::HttpCache` in [config/initializers/ohanapi.rb](https://github.com/codeforamerica/ohana-web-search/blob/master/config/initializers/ohanapi.rb), and the other is caching the entire results page and/or location details page.
+See our Wiki article on [improving performance with caching][caching].
 
-API request caching is turned on by default, and will prevent the app from making the same API request for a [period of time specified by the API](https://github.com/codeforamerica/ohana-api/blob/master/config/application.example.yml#L82-89). By default, that is set to 5 minutes. That means that if a location's info has changed on the API side, if Ohana Web Search had already requested that same location, the latest data changes won't appear in Ohana Web Search until 5 minutes have passed since the first request was made.
-
-As for page caching, it is disabled by default. If you determine that you need to cache pages, you can turn it on by setting the `ENABLE_CACHING` environment variable on your production server to `true`. If you're using Heroku, you can set it like this:
-```
-$ heroku config:set ENABLE_CACHING=true -a your_heroku_app_name
-```
-
-When page caching is enabled, it will store the page in Memcached via the [MemCachier add-on on Heroku](https://addons.heroku.com/memcachier) (by default) so that the next time any browser requests that same page, it will be served from cache instead of the server. In addition to the app storing the page in Memcached, most modern browsers will also store the page in their cache, and will send an `If-Modified-Since` date in the Request Headers to ask the server if a newer version exists.
-
-Because the `If-Modified-Since` date is based on the `updated_at` field returned by the API, any changes you make to the page will not appear on the website as long as the `updated_at` field hasn't changed, and as long as the browser is still fetching the page from its cache. In order to invalidate the cache for your site visitors, you'll need to flush the MemCachier cache, and update the `updated_at` field for all of the locations in the API.
-
-To flush the MemCachier cache on Heroku, run the following command:
-
-    heroku run -a your_app_name rails runner -e production Rails.cache.clear
-
-To update the `updated_at` field, follow these steps:
-
-1. Run the Rails console for your instance of the Ohana API (not Ohana Web Search) on Heroku:
-
-   ```
-   $ heroku run rails c -a your_api_app_name
-   ```
-
-2. Update all locations:
-
-   ```
-   > Location.find_each(&:touch)
-   ```
-
-3. Quit the console:
-
-   ```
-   > quit
-   ```
-
-Note that this is only one caching solution. For other caching strategies, visit the following resources:
-
-[https://devcenter.heroku.com/articles/http-caching-ruby-rails](https://devcenter.heroku.com/articles/http-caching-ruby-rails)
-
-[https://devcenter.heroku.com/articles/caching-strategies](https://devcenter.heroku.com/articles/caching-strategies)
-
-[http://railscasts.com/episodes/321-http-caching](http://railscasts.com/episodes/321-http-caching)
+[caching]: https://github.com/codeforamerica/ohana-web-search/wiki/Improving-performance-with-caching

--- a/app/controllers/concerns/cacheable.rb
+++ b/app/controllers/concerns/cacheable.rb
@@ -1,6 +1,7 @@
 module Cacheable
   def cache_page(field)
     return unless ENV['ENABLE_CACHING'] == 'true'
-    fresh_when last_modified: field, public: true
+    fresh_when(
+    etag: ENV['ETAG_VERSION_ID'], last_modified: field, public: true)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,15 +1,18 @@
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:
-# require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
-# require 'active_resource/railtie'
 require 'sprockets/railtie'
 
 SETTINGS = YAML.load(File.read(File.expand_path('../settings.yml', __FILE__)))
 SETTINGS.merge! SETTINGS.fetch(Rails.env, {})
 SETTINGS.symbolize_keys!
+
+# Set the Etag to the first few characters of the latest commit's SHA1.
+# This allows the browser cache to be invalidated every time you
+# push a new commit to production.
+ENV['ETAG_VERSION_ID'] = `git log --pretty=format:%h -n1`.strip
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,9 +13,19 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.consider_all_requests_local = true
+
+  # Uncomment lines 22-28 below to test HTTP caching in development.
+  # Visit the Wiki for more details:
+  # https://github.com/codeforamerica/ohana-web-search/wiki/Improving-performance-with-caching
+  #
+  # config.action_controller.perform_caching = true
   # config.cache_store = :dalli_store
+  # client = Dalli::Client.new
+  # config.action_dispatch.rack_cache = {
+  #   metastore: client,
+  #   entitystore: client
+  # }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -41,12 +51,6 @@ Rails.application.configure do
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
-
-  # If the app is not using active_record/railtie (see application.rb),
-  # the setting below should be disabled.
-  #
-  # Raise an error on page load if there are pending migrations.
-  # config.active_record.migration_error = :page_load
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large


### PR DESCRIPTION
By only relying on `last_modified`, invalidating the browser cache would involve updating every Location on the API side, which is not ideal.

By adding the Etag to the mix, and setting it to the SHA-1 from the latest git commit, we can invalidate the browser cache by simply pushing new code to production (or even just manually setting the `ETAG_VERSION_ID` config var).
