### PR TITLE
Fixes #571 - removes last updated field

### DIFF
--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -1267,23 +1267,8 @@ body {
   .metadata {
     // Clear any floats to prevent overlap into footer.
     clear: both;
-
-    // Stylize timestamp.
-    .updated-at {
-      text-align: right;
-      font-size: $font_size_90;
-      font-family: $font_san_serif;
-
-      > h1 {
-        padding: 0;
-        background: transparent;
-        font-size: $font_size_90;
-      }
-
-      div {
-        font-size: $font_size_100;
-      }
-    }
+    text-align: right;
+    padding: 0 20px 20px 20px;
   }
 }
 

--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -215,14 +215,6 @@
     }
 
     #detail-info .metadata {
-
-      .updated-at {
-        float: right;
-        margin: 0;
-        padding: 0;
-        padding-right: 20px;
-      }
-
       .button-edit {
         display: none !important;
       }

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -177,13 +177,7 @@
 
     %footer
       %section.metadata
-        %section
-          %section.updated-at
-            %h1
-              Last updated:
-            %span
-              = @location.updated_at.to_s(:full_date_and_time)
-            .button-edit
-              = link_to "#{SETTINGS[:admin_site]}/locations/#{@location.slug}", rel: 'nofollow' do
-                %i.fa.fa-pencil
-                Edit
+        .button-edit
+          = link_to "#{SETTINGS[:admin_site]}/locations/#{@location.slug}", rel: 'nofollow' do
+            %i.fa.fa-pencil
+            Edit

--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -170,10 +170,6 @@ feature 'location details' do
     it 'sets the page title to the location name + site title' do
       expect(page).to have_title('Example Location | Ohana Web Search')
     end
-
-    it 'includes updated time' do
-      expect(page).to have_content('Tuesday, 18 November 2014 at 5:37 AM PST')
-    end
   end
 
   context 'when Contact elements are present' do
@@ -241,7 +237,7 @@ feature 'location details' do
     end
 
     it 'includes rel=nofollow' do
-      within '.updated-at' do
+      within '.button-edit' do
         expect(find(:rel, 'nofollow')).to be_present
       end
     end


### PR DESCRIPTION
Fixes #571 - removes last updated field as this was not an accurate
indication of when the data was last updated. This should be replaced
in the future with an accurate mechanism for displaying the last
updated timestamp if possible, as this is valuable information to
include.