### PR TITLE
Fixes #730 - handles when translations are empty

### DIFF
--- a/app/services/keyword_translator.rb
+++ b/app/services/keyword_translator.rb
@@ -45,7 +45,7 @@ class KeywordTranslator
   end
 
   def translated_keyword
-    return keyword if translations.nil?
+    return keyword if translations.blank?
     translations.first.translatedText
   end
 


### PR DESCRIPTION
Fixes #730 - handles when translations return an empty result set, such
as when the account is over quota (billing is not enabled).