### PR TITLE
Performs test cleanup

### DIFF
--- a/spec/features/details/address_formatting_spec.rb
+++ b/spec/features/details/address_formatting_spec.rb
@@ -25,18 +25,8 @@ feature 'address formatting' do
       expect(page).to have_content('Physical Address')
     end
 
-    it 'includes the physical address' do
-      address = '2013 Avenue of the fellows, Suite 100 San Francisco, CA 94103'
-      expect(page).to have_content(address)
-    end
-
     it 'includes the mailing address header' do
       expect(page).to have_content('Mailing Address')
-    end
-
-    it 'includes the mailing address' do
-      address = 'The Foodies 2013 Avenue of the fellows, Suite 100 San Francisco, CA 90210'
-      expect(page).to have_content(address)
     end
 
     it 'includes a Google Maps directions link to the address' do

--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -155,12 +155,14 @@ feature 'location details' do
       expect(page).to have_link('www.example.org')
     end
 
-    it 'includes Physical Address' do
-      expect(page).to have_content('Avenue of the fellows')
+    it 'includes the physical address' do
+      address = '2013 Avenue of the fellows, Suite 100 San Francisco, CA 94103'
+      expect(page).to have_content(address)
     end
 
-    it 'includes Mailing Address' do
-      expect(page).to have_content('The Foodies')
+    it 'includes the mailing address' do
+      address = 'The Foodies 2013 Avenue of the fellows, Suite 100 San Francisco, CA 90210'
+      expect(page).to have_content(address)
     end
 
     xit 'includes keywords' do

--- a/spec/features/details/location_service_details_spec.rb
+++ b/spec/features/details/location_service_details_spec.rb
@@ -43,7 +43,8 @@ feature 'location service details' do
     end
 
     it 'includes eligibility' do
-      expect(page).to have_content('None')
+      element = '.services-box .eligibility'
+      expect(all(element).last).to have_content('None')
     end
 
     it 'includes how to apply' do
@@ -56,7 +57,7 @@ feature 'location service details' do
 
     it 'includes required documents' do
       element = '.services-box .required-documents'
-      expect(first(element)).to have_content('Government-issued picture identification')
+      expect(first(element)).to have_content('Government-issued picture')
     end
 
     it 'includes accepted payment methods' do


### PR DESCRIPTION
- Moves address tests from address formatting spec and adds them to
location details spec, to remove redundant checks for the address
between those two specs.
- Adds a selector to the eligibility test, as the Fees field has the
content ‘None’ as well, so if the eligibility field was removed the
test would still pass because it’s checking the whole page.
- Shortens the required-documents test to fit within 80 characters.