### PR TITLE
Fixes #496 - removes redundant floating header.

### DIFF
--- a/app/assets/javascripts/result/result-init.js
+++ b/app/assets/javascripts/result/result-init.js
@@ -7,7 +7,6 @@ function (map, header) {
 
   map.init();
   header.init();
-
 },
 function (err) {
   'use strict';

--- a/app/assets/javascripts/search/header.js
+++ b/app/assets/javascripts/search/header.js
@@ -11,34 +11,45 @@ function (util) {
 
   function init() {
     _header = document.getElementById('floating-results-header');
-    if (_header) {
-      _offsetY = util.getOffset(_header).top;
-      var query = '#floating-results-header .floating-content';
-      _floatingContent = document.querySelectorAll(query);
+    if (!_header) throw new Error('Floating header DOM not found!');
+    _offsetY = _calculateOffset();
+    _floatingContent = _header.querySelectorAll('.floating-content');
 
-      _checkIfFloating();
+    _checkIfFloating();
 
-      // If the URL has a hash, offset the scrolling by the height of the
-      // floating header. Also offset scrolling if search container is
-      // above search results (it's not floated).
-      var scrollOffset;
-      if (window.location.hash) {
-        scrollOffset = _header.offsetHeight;
-        window.scrollTo(0, (window.scrollY - scrollOffset));
-      } else if ( (util.getStyle(document.getElementById('search-container'),
-                  'float') === 'none')
-                ) {
-        var header = document.getElementById('persistent-results-header');
-        scrollOffset = util.getOffset(header).top;
-        window.scrollTo(0, scrollOffset - 1);
-      }
-
-      window.addEventListener('scroll', _onScroll, false);
+    // If the URL has a hash, offset the scrolling by the height of the
+    // floating header. Also offset scrolling if search container is
+    // above search results (it's not floated).
+    var scrollOffset;
+    if (window.location.hash) {
+      scrollOffset = _header.offsetHeight;
+      window.scrollTo(0, (window.scrollY - scrollOffset));
+    } else if ( (util.getStyle(document.getElementById('search-container'),
+                'float') === 'none')
+              ) {
+      scrollOffset = _calculateOffset();
+      window.scrollTo(0, scrollOffset - 1);
     }
+
+    window.addEventListener('scroll', _onScroll, false);
+    window.addEventListener('resize', _resizeHandler, true);
+  }
+
+  function _resizeHandler() {
+    _offsetY = _calculateOffset();
   }
 
   function _onScroll() {
     _checkIfFloating();
+  }
+
+  function _calculateOffset() {
+    var isFloating = _header.classList.contains('floating');
+    _header.classList.remove('floating');
+    var offset = util.getOffset(_header).top;
+    if (isFloating)
+      _header.classList.add('floating');
+    return offset;
   }
 
   function _checkIfFloating() {

--- a/app/assets/stylesheets/_base.css.scss
+++ b/app/assets/stylesheets/_base.css.scss
@@ -593,8 +593,10 @@ body {
     padding-left: 20px;
     padding-top: 9px;
     padding-bottom: 6px;
+    padding-right: 20px;
     color: $black;
     font-family: $font_serif;
+    @include ellipsis();
   }
 
   // Print, Email, Directions, Back to search
@@ -619,16 +621,17 @@ body {
   }
 
   .left-column {
-    float: left;
-    z-index: 9998;
+    z-index: $layer-7;
+    text-align: left;
 
-    > * {
+    > .static-content, {
       @include inline-block();
     }
   }
 
   .right-column {
-    z-index: 9997;
+    float: right;
+    z-index: $layer-8;
 
     > * {
       @include inline-block();
@@ -640,6 +643,7 @@ body {
     padding-top: 10px;
     padding-bottom: 10px;
     padding-right: 20px;
+    @include inline-block();
 
     > * {
       @include inline-block();
@@ -678,11 +682,6 @@ body {
   padding: 20px;
 }
 
-.results-header.persistent {
-  position: static;
-  visibility: hidden;
-}
-
 .results-header.floating {
   -webkit-backface-visibility: hidden;
   width: 100%;
@@ -692,6 +691,8 @@ body {
 
 #results-entries {
   min-height: 475px;
+  // Offset to accommodate the floating header height.
+  padding-top: 45px;
 
   > ul {
     padding: 0;
@@ -985,13 +986,15 @@ body {
 }
 
 //=================================================================================
-// Detail list screen
+// Location details view.
 #detail-info {
   background: $greyscale_lightest;
   color: $black;
   font-family: $font_san_serif;
+  // Offset to accommodate the floating header height.
+  padding-top: 45px;
 
-  // Section header
+  // Location header.
   > header {
     padding: 10px;
     border-bottom: 1px solid $greyscale_light; // IE fallback
@@ -1030,7 +1033,7 @@ body {
     }
   }
 
-  // Format detail sections.
+  // Individual location detail sections.
   > * > section {
 
     > section:only-of-type {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -29,6 +29,7 @@
 @import "compass/css3/inline-block";
 @import "compass/css3/user-interface";
 @import "compass/css3/background-size";
+@import "compass/typography/text/ellipsis";
 @import "compass/typography/vertical_rhythm";
 
 /* ==========================================================================

--- a/app/assets/stylesheets/responsive.css.scss
+++ b/app/assets/stylesheets/responsive.css.scss
@@ -226,13 +226,10 @@
         margin-right: 10px;
       }
     }
-
-
   }
 
 
-  .inside
-  {
+  .inside {
     #results-container {
       margin-left: 0;
       border-left: 0;
@@ -265,15 +262,6 @@
 
       .button-print-container {
         display: none;
-      }
-
-      .button-share-email,
-      .button-map-zoom {
-        border-left: 1px dotted $greyscale_light;
-      }
-
-      .button-top {
-        border-right: 1px dotted $greyscale_light;
       }
 
       .pagination {

--- a/app/views/component/locations/detail/_header.html.haml
+++ b/app/views/component/locations/detail/_header.html.haml
@@ -1,6 +1,2 @@
 %header.results-header#floating-results-header
   = render partial: 'component/locations/detail/header_summary', locals: { location: @location }
-
--# Persistent header duplicate needed to maintain layout when header floats.
-%header.results-header.persistent#persistent-results-header
-  = render partial: 'component/locations/detail/header_summary', locals: { location: @location }

--- a/app/views/component/locations/detail/_header_summary.html.haml
+++ b/app/views/component/locations/detail/_header_summary.html.haml
@@ -1,37 +1,30 @@
 %div
-  .left-column
-
-    .floating-content.hide
-      %h1
-        = superscript_ordinals(full_name_content_for(@location))
-
   .right-column
-
     .floating-content.hide><
-
       %span
         %a.button-utility.button-top{ href: '#' }
           %i.fa.fa-chevron-up
           Top
-
     %span.utility-links
       %span.button-print-container><
         %a.button-utility.button-print.hide{ href: '#' }
           %i.fa.fa-print
           Print
-
       %span><
         %a.button-utility.button-share-email{ href: mailto_url }
           %i.fa.fa-share
           Email
-
       - if location.coordinates.present?
         %span><
           %a.button-utility.button-directions{ href: "https://maps.google.com/maps?saddr=current+location&daddr=#{full_address_for(location.address)}", target: '_blank' }
             %i.fa.fa-external-link-square
             %span Directions
-
       %span
         %a.button-utility.button-back{ href: "#{locations_url(request.query_parameters)}##{location.id}", target: '_self' }
           %i.fa.fa-arrow-circle-left
           Back
+
+  .left-column
+    .floating-content.hide
+      %h1
+        = superscript_ordinals(full_name_content_for(@location))

--- a/app/views/component/locations/results/_header.html.haml
+++ b/app/views/component/locations/results/_header.html.haml
@@ -1,6 +1,2 @@
 %header.results-header#floating-results-header
   = render 'component/locations/results/header_summary'
-
--# Persistent header duplicate needed to maintain layout when header floats
-%header.results-header.persistent#persistent-results-header
-  = render 'component/locations/results/header_summary'

--- a/app/views/component/locations/results/_header_summary.html.haml
+++ b/app/views/component/locations/results/_header_summary.html.haml
@@ -1,4 +1,13 @@
 %div
+  .right-column
+    .floating-content.hide><
+      %span
+        %a.button-utility.button-top{ href: '#' }
+          %i.fa.fa-chevron-up
+          Top
+
+    = paginate @search.results
+
   .left-column
     %span.static-content><
       - if @search.map_data.size != 0
@@ -11,12 +20,3 @@
 
       %span.map-summary.static-content
         = map_summary if @search.map_data.size != 0
-
-  .right-column
-    .floating-content.hide><
-      %span
-        %a.button-utility.button-top{ href: '#' }
-          %i.fa.fa-chevron-up
-          Top
-
-    = paginate @search.results

--- a/spec/features/search/pagination_spec.rb
+++ b/spec/features/search/pagination_spec.rb
@@ -9,7 +9,7 @@ feature 'results page pagination', :vcr do
     end
 
     it 'displays an appropriate search summary' do
-      within('#persistent-results-header .search-summary') do
+      within('#floating-results-header .search-summary') do
         expect(page).to have_content('No results found')
       end
     end
@@ -23,7 +23,7 @@ feature 'results page pagination', :vcr do
     end
 
     it 'displays an appropriate search summary' do
-      within('#persistent-results-header .search-summary') do
+      within('#floating-results-header .search-summary') do
         expect(page).to have_content('Displaying 1 result')
       end
     end
@@ -41,7 +41,7 @@ feature 'results page pagination', :vcr do
     end
 
     it 'displays an appropriate search summary' do
-      within('#persistent-results-header .search-summary') do
+      within('#floating-results-header .search-summary') do
         expect(page).to have_content('Displaying all 3 results')
       end
     end
@@ -63,7 +63,7 @@ feature 'results page pagination', :vcr do
     end
 
     it 'displays an appropriate search summary' do
-      within('#persistent-results-header .search-summary') do
+      within('#floating-results-header .search-summary') do
         expect(page).to have_content('Displaying 1 - 1 of 3 results')
       end
     end

--- a/spec/features/search/search_summary_spec.rb
+++ b/spec/features/search/search_summary_spec.rb
@@ -3,20 +3,20 @@ require 'rails_helper'
 feature 'Search summary' do
   scenario 'when visiting search results page that has results', :vcr do
     search_for_example
-    # Expect only static and floating search results summary,
-    # and expect that they're only in the results-header.
-    expect(all('.search-summary', text: 'Displaying 1 result').count).to eq(2)
+    # Expect only floating search results summary,
+    # and expect that it's only in the results-header.
+    expect(all('.search-summary', text: 'Displaying 1 result').count).to eq(1)
     expect(all('.results-header .search-summary', text: 'Displaying 1 result').
-      count).to eq(2)
+      count).to eq(1)
   end
 
   scenario 'when visiting search results page that does not have results',
            :vcr do
     search_for_no_results
-    # Expect only static and floating search results summary,
-    # and expect that they're only in the results-header.
-    expect(all('.search-summary', text: 'No results').count).to eq(2)
+    # Expect only floating search results summary,
+    # and expect that it's only in the results-header.
+    expect(all('.search-summary', text: 'No results').count).to eq(1)
     expect(all('.results-header .search-summary', text: 'No results').count).
-      to eq(2)
+      to eq(1)
   end
 end


### PR DESCRIPTION
- Fixes #496 - Uses text-overflow:ellipsis to truncate floating header
text so that header can be a fixed height, removing the need to have a
duplicate reference header. Truncating the text required reversing the
float direction of the left and right columns in the header and
updating the tests to reference the floating header instead of the
persistent header.