### PR TITLE
Updates jshint to 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       hpricot (~> 0.8.6)
       ruby_parser (~> 3.1.1)
     i18n (0.7.0)
-    jshint (1.2.0)
+    jshint (1.3.1)
       execjs (>= 1.4.0)
       multi_json (~> 1.0)
       therubyracer (~> 0.12.1)


### PR DESCRIPTION
Updates jshint to 1.3.1 from 1.2.0. See changes at
https://github.com/damian/jshint/blob/master/CHANGELOG.md