### PR TITLE
Updates faraday-http-cache to 1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'haml-rails'
 
 gem 'unicorn'
 gem 'ohanakapa', '~> 1.1.1'
-gem 'faraday-http-cache', '~> 0.4.0'
+gem 'faraday-http-cache'
 
 # Caching
 gem 'rack-cache', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,9 @@ GEM
     erubis (2.7.0)
     execjs (2.2.2)
     extlib (0.9.16)
-    faraday (0.9.0)
+    faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (0.4.2)
+    faraday-http-cache (1.0.1)
       faraday (~> 0.8)
     ffi (1.9.6)
     figaro (1.0.0)
@@ -309,7 +309,7 @@ DEPENDENCIES
   coveralls
   dalli (~> 2.7.1)
   email_spec (~> 1.6.0)
-  faraday-http-cache (~> 0.4.0)
+  faraday-http-cache
   figaro (~> 1.0.0)
   font-awesome-rails
   google-api-client (~> 0.8.1)


### PR DESCRIPTION
Updates faraday-http-cache to 1.0.1 from 0.4.2. Removes version
requirement from gem file, per faraday-http-cache gem installation
instructions
https://github.com/plataformatec/faraday-http-cache#installation.