### PR TITLE
Updates Spring to 1.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    spring (1.2.0)
+    spring (1.3.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     spring-watcher-listen (1.0.0)


### PR DESCRIPTION
Updates Spring to 1.3.2 from 1.2.0. Changelog —>
https://github.com/rails/spring/blob/master/CHANGELOG.md