### PR TITLE
Can't call git commands on Heroku.

### DIFF
--- a/app/controllers/concerns/cacheable.rb
+++ b/app/controllers/concerns/cacheable.rb
@@ -2,6 +2,10 @@ module Cacheable
   def cache_page(field)
     return unless ENV['ENABLE_CACHING'] == 'true'
     fresh_when(
-      etag: ENV['ETAG_VERSION_ID'], last_modified: field, public: true)
+      etag: latest_commit_hash, last_modified: field, public: true)
+  end
+
+  def latest_commit_hash
+    ENV['LATEST_COMMIT_HASH']
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,11 +9,6 @@ SETTINGS = YAML.load(File.read(File.expand_path('../settings.yml', __FILE__)))
 SETTINGS.merge! SETTINGS.fetch(Rails.env, {})
 SETTINGS.symbolize_keys!
 
-# Set the Etag to the first few characters of the latest commit's SHA1.
-# This allows the browser cache to be invalidated every time you
-# push a new commit to production.
-ENV['ETAG_VERSION_ID'] = `git log --pretty=format:%h -n1`.strip
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
After you push to Heroku, Heroku removes the `.git` folder, so any `git` commands will result in `fatal: Not a git repository (or any of the parent directories): .git`.

One solution is to set the environment variable on Heroku with a git pre-push hook as explained here:
http://stackoverflow.com/a/22702304

See the Wiki for other solutions:
https://github.com/codeforamerica/ohana-web-search/wiki/Improving-performance-with-caching

The purpose of this code is to allow the browser cache to be invalidated when a new release is pushed to Heroku by setting the `Etag` to the latest commit hash.