### PR TITLE
Pagination component

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -889,6 +889,7 @@ body {
   footer {
     margin-right: 20px;
     text-align: right;
+    max-height: 44px;
   }
 }
 

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -63,7 +63,7 @@
     background:$pagination-next-bg;
     a
     {
-      color:$pagination-next-color;
+      color:$pagination-next-color !important;
       border-bottom:none;
     }
     a:hover

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -296,7 +296,7 @@
 
     #results-entries {
 
-      nav {
+      > nav {
         margin-top: 15px;
         margin-left: 15px;
         margin-right: 15px;


### PR DESCRIPTION
This is a fix for issue #774 

The 1 pixel space was fixed by setting the footer height to the same height as the pagination component.

The issue with the wrong color for the arrow was being caused by inheriting a color from list-view li a in _base.scss

I also found an issue with the responsiveness of the site. The bottom bar (footer) was getting too big, because the pagination bar was inheriting margins it shouldn't have been (I fixed this as well). Here's a photo of what I mean:



![screen shot 2015-03-11 at 7 45 17 pm](https://cloud.githubusercontent.com/assets/2323292/6611258/85bf8fe6-c827-11e4-8662-a48599b64404.png)
