### PR TITLE
map size is saved between page changes

### DIFF
--- a/app/assets/javascripts/result/result-map.js
+++ b/app/assets/javascripts/result/result-map.js
@@ -13,6 +13,9 @@ function (markerDataLoader, googleMaps, plugins, mapRenderer, MapSizeControl) {
   // Whether the Google Map APIs and plugins have successfully loaded.
   var _mapStackReady = false;
 
+  //Whether the map is at its max size or not
+  var _atMaxSize;
+
   function init() {
     // Load map marker data from DOM.
     var markerData = markerDataLoader.loadData('#map-locations-data');
@@ -33,6 +36,16 @@ function (markerDataLoader, googleMaps, plugins, mapRenderer, MapSizeControl) {
     mapRenderer.renderMapStack();
     var mapSizeControl = MapSizeControl.create('#map-size-control');
     mapSizeControl.addEventListener('click', _mapSizeControlClicked);
+    _setMapSize();
+  }
+
+  function _setMapSize() {
+    if (typeof(sessionStorage) !== 'undefined' && sessionStorage.atMaxSize !== undefined) {
+      _atMaxSize = JSON.parse(sessionStorage.atMaxSize) || false;
+      if (_atMaxSize !== false) {
+        document.getElementById('map-size-control').click();
+      }
+    }
   }
 
   function _mapSizeControlClicked() {

--- a/app/assets/javascripts/util/map/MapSizeControl.js
+++ b/app/assets/javascripts/util/map/MapSizeControl.js
@@ -39,6 +39,9 @@ function (eventObserver) {
     // Map size control was clicked. This control toggles the large & small map.
     function _buttonElmClicked(evt) {
       _atMaxSize = !_atMaxSize;
+      if (typeof(sessionStorage) !== 'undefined') {
+        sessionStorage.atMaxSize = JSON.stringify(_atMaxSize) || false;
+      }
       _buttonElm.innerHTML = _atMaxSize ? LARGER_MAP_TEXT : SMALLER_MAP_TEXT;
       _instance.dispatchEvent(_events.CLICK, {target:_instance});
       evt.preventDefault();


### PR DESCRIPTION
This is a fix for issue #612. I couldn't figure out how to write a test for this because AFAIK the button to trigger map size is not loaded in the test environment. 

I used session storage which will save the map size within the current tab. If we want it to be persistent, I can easily switch it to local storage.