### PR TITLE
Fetch Google fonts over HTTPS

### DIFF
--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -34,8 +34,8 @@
 
 = csrf_meta_tags
 
-= stylesheet_link_tag 'http://fonts.googleapis.com/css?family=Libre+Baskerville:400,700'
-= stylesheet_link_tag 'http://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700'
+= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Libre+Baskerville:400,700'
+= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700'
 = stylesheet_link_tag 'application', media: 'all'
 
 -# Include scripts from outside of RequireJS modular system (e.g. Modernizr).


### PR DESCRIPTION
This allows the fonts to work when browsing the site over HTTPS.