### PR TITLE
Use config var to turn force_ssl setting on or off.

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -12,7 +12,7 @@ If you're planning on deploying the app to Heroku, you can set all the required 
 ```
 $ script/setup_heroku -a your_app_name -o your_api_endpoint
 ```
-`your_api_endpoint` is the URL to your instance of Ohana API, such as `http://ohana-api-demo.herokuapp.com/api`. `your_app_name` is your Heroku app's name. Read the [script](https://github.com/codeforamerica/ohana-web-search/blob/master/script/setup_heroku) for more details about what it will install.
+`your_api_endpoint` is the URL to your instance of Ohana API, such as `https://ohana-api-demo.herokuapp.com/api`. `your_app_name` is your Heroku app's name. Read the [script](https://github.com/codeforamerica/ohana-web-search/blob/master/script/setup_heroku) for more details about what it will install.
 
 The script only sets required environment variables. To set optional environment variables on Heroku, such as `GOOGLE_ANALYTICS_ID`, you'll need to set them manually. Read through `application.example.yml` to learn about all the optional variables you can set, and read the Heroku documentation to learn how to [set Heroku configuration variables](https://devcenter.heroku.com/articles/config-vars).
 
@@ -52,7 +52,7 @@ To change the labels for the navigation buttons, visit the [pagination](https://
 
 To test the pagination feature, you might find it handy to force a particular
 number of results per page by adding the `per_page` parameter to the end of the
-URL. For example: [http://ohana-web-search-demo.herokuapp.com/locations?utf8=%E2%9C%93&keyword=&location=&per_page=5](http://ohana-web-search-demo.herokuapp.com/locations?utf8=%E2%9C%93&keyword=&location=&per_page=5)
+URL. For example: [https://ohana-web-search-demo.herokuapp.com/locations?utf8=%E2%9C%93&keyword=&location=&per_page=5](https://ohana-web-search-demo.herokuapp.com/locations?utf8=%E2%9C%93&keyword=&location=&per_page=5)
 
 ## Custom graphics
 The root `graphics` folder contains source template files for images in the application. Using these templates you can edit and re-generate the major graphics of the application. These are provided in Adobe Illustrator and SVG formats.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We gladly welcome contributions. Below you will find instructions for installing
 
 ## Demo
 You can see a running version of the application at
-[http://ohana-web-search-demo.herokuapp.com/](http://ohana-web-search-demo.herokuapp.com/).
+[https://ohana-web-search-demo.herokuapp.com/](https://ohana-web-search-demo.herokuapp.com/).
 
 ## Stack Overview
 

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,6 +1,9 @@
 # This file is used by the "figaro" gem to allow you to store and use
 # environment variables in the app without having to set them via the
-# command line each time you run the app in development.
+# command line each time you run the app in development. Another advantage
+# is that you can make changes in a production environment (such as Heroku)
+# by simply changing the value of the environment variable, as opposed to
+# making code changes and having to push them to apply the new setting.
 # Read more about figaro here: https://github.com/laserlemon/figaro
 
 # Note that changes to this file will require a server restart to take effect.
@@ -9,14 +12,32 @@
 # in the Unix shell. For example, setting:
 # OHANA_API_ENDPOINT: https://ohana-api-demo.herokuapp.com/api
 # makes "https://ohana-api-demo.herokuapp.com/api" available as
-# ENV["OHANA_API_ENDPOINT"] in the app. See config/initializers/ohanapi.rb
+# ENV['OHANA_API_ENDPOINT'] in the app. See config/initializers/ohanapi.rb
 # for a usage example.
 
-# Set this to the URL for your instance of the Ohana API:
-# https://github.com/codeforamerica/ohana-api
-# This environment variable is required.
-OHANA_API_ENDPOINT: https://ohana-api-demo.herokuapp.com/api
+# Below, you will find descriptions for each variable, followed by default
+# settings for the development, production, and test environments.
 
+####################################
+#
+# ENVIRONMENT VARIABLE DESCRIPTIONS
+#
+####################################
+
+##############################################
+#
+# CANONICAL_URL - REQUIRED FOR CUSTOM DOMAINS
+#
+##############################################
+# If you are using a custom domain name, set CANONICAL_URL to your preferred
+# domain name, such as 'example.org' or 'www.example.org'.
+# See config/environments/production.rb for more details.
+
+################################################
+#
+# DOMAIN_NAME - REQUIRED FOR GOOGLE TRANSLATION
+#
+################################################
 # This setting is used for the Google translation feature.
 # The "DOMAIN_NAME" environment variable should be set to your app's
 # domain name, without the "www" subdomain, unless you're using a Heroku
@@ -33,13 +54,39 @@ OHANA_API_ENDPOINT: https://ohana-api-demo.herokuapp.com/api
 # Read more about lvh.me here:
 # http://matthewhutchinson.net/2011/1/10/configuring-subdomains-in-development-with-lvhme
 # Pow should work too if you prefer that: http://pow.cx/
-DOMAIN_NAME: lvh.me
 
+########################################
+#
+# ENABLE_HTTPS - REQUIRED IN PRODUCTION
+#
+########################################
+# When using the default Heroku domain setup (http://app-name.herokuapp.com),
+# you can take advantage of SSL for free. However, to use SSL with a custom
+# domain name, you'll need to do some work first, as explained in the Wiki:
+# http://git.io/vez1W
+
+################################
+#
+# OHANA_API_ENDPOINT - REQUIRED
+#
+################################
+# Set this to the URL for your instance of the Ohana API:
+# https://github.com/codeforamerica/ohana-api
+
+################################
+#
+# OHANA_API_TOKEN - OPTIONAL
+#
+################################
 # If you choose to turn on rate limiting in your instance of Ohana API,
 # obtain an API Token for this app from the developer portal of the API,
-# then replace "changeme" with the actual token below.
-# OHANA_API_TOKEN: changeme
+# then replace "changeme" with the actual token.
 
+######################################
+#
+# GOOGLE_TRANSLATE_API_KEY - OPTIONAL
+#
+######################################
 # If the page has been translated to a language other than English
 # and you would like your users to be able to type in search keywords
 # in that language, you will need to sign up for a paid
@@ -49,8 +96,12 @@ DOMAIN_NAME: lvh.me
 # Once you obtain your API key, uncomment translation-related code in
 # app/controllers/locations_controller and enter your API key below to
 # test the translation in development.
-# GOOGLE_TRANSLATE_API_KEY: Your_API_Key
 
+#################################################
+#
+# GOOGLE_TRANSLATE_CUSTOMIZATION_CODE - OPTIONAL
+#
+#################################################
 # To allow users to customize the translations on your site, include a
 # Google Translate Customization website code. This code is used to verify
 # ownership for the Google Website Translator so that custom translations are
@@ -61,38 +112,61 @@ DOMAIN_NAME: lvh.me
 # via the Google Website Translator Gadget Wizard at
 # https://translate.google.com/manager/website/
 # and clicking "Get Code" when prompted.
-# GOOGLE_TRANSLATE_CUSTOMIZATION_CODE: Your_Website_Code_from_Google
 
+#################################################
+#
+# GOOGLE_ANALYTICS_ID - OPTIONAL
+# GOOGLE_ANALYTICS_DOMAIN - OPTIONAL
+#
+#################################################
 # If you have a Google Analytics account you want to use to track visits
 # to this app, set your ID and domain name below.
 # An example ID is 'UA-40905632-1', and an example domain is 'smc-connect.org'.
 # Note that you must have a Universal Analytics property for tracking to work.
 # https://support.google.com/analytics/answer/4457764?hl=en
-# GOOGLE_ANALYTICS_ID:
-# GOOGLE_ANALYTICS_DOMAIN:
 
+#################################################
+#
+# GOOGLE_MAPS_API_KEY - OPTIONAL
+#
+#################################################
 # While not required, using a Google Maps API key enables you to monitor your
 # application's Maps API usage. If your usage exceeds Google's usage limits,
 # you must load the Maps API using an API key in order to purchase more quota.
 # Visit the following URL for more information and to setup an API key:
 # https://developers.google.com/maps/documentation/javascript/tutorial#api_key
-# GOOGLE_MAPS_API_KEY:
 
-# When you visit a location, for example,
-# http://ohana-web-search-demo.herokuapp.com/locations/salvation-army/sunnyvale-corps,
-# the 'Last updated' time that is displayed at the bottom right of the page is
-# set to UTC by default. If you would like to set it to a more appropriate
-# time zone where most of your visitors live, you can set the 'TZ' environment
-# variable to one of the accepted values:
-# http://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
-# For example, to set the time zone to Eastern Time, you would set the 'TZ'
-# value below to 'America/New_York'.
-# TZ:
+###########################
+#
+# SETTINGS FOR DEVELOPMENT
+#
+###########################
+development:
+  DOMAIN_NAME: lvh.me
+  # GOOGLE_MAPS_API_KEY:
+  # GOOGLE_TRANSLATE_API_KEY: Your_API_Key
+  # GOOGLE_TRANSLATE_CUSTOMIZATION_CODE: Your_Website_Code_from_Google
+  OHANA_API_ENDPOINT: https://ohana-api-demo.herokuapp.com/api
+  # OHANA_API_TOKEN: changeme
 
-# If you are using a custom domain name, set CANONICAL_URL to your preferred
-# domain name, such as 'example.org' or 'www.example.org'.
-# See config/environments/production.rb for more details.
-# CANONICAL_URL:
+###############################################################################
+#
+# SETTINGS FOR PRODUCTION.
+#
+# Run `figaro heroku:set -e production -a your_app_name` to set them on Heroku.
+#
+###############################################################################
+production:
+  # CANONICAL_URL:
+  DOMAIN_NAME: changeme
+  ENABLE_HTTPS: 'yes'
+  # GOOGLE_ANALYTICS_ID:
+  # GOOGLE_ANALYTICS_DOMAIN:
+  # GOOGLE_MAPS_API_KEY:
+  # GOOGLE_TRANSLATE_API_KEY: Your_API_Key
+  # GOOGLE_TRANSLATE_CUSTOMIZATION_CODE: Your_Website_Code_from_Google
+  OHANA_API_ENDPOINT: https://ohana-api-demo.herokuapp.com/api
+  # OHANA_API_TOKEN: changeme
 
 ###############################################################################
 #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -134,7 +134,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = (ENV['ENABLE_HTTPS'] == 'yes')
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/settings.example.yml
+++ b/config/settings.example.yml
@@ -13,7 +13,7 @@
 # When viewing the details page for a location, there is an 'Edit' link
 # at the bottom of the page that takes you to the corresponding location
 # in the admin interface. Below, specify the URL for your Admin site.
-admin_site: http://ohana-api-demo.herokuapp.com/admin
+admin_site: https://ohana-api-demo.herokuapp.com/admin
 
 ##########################
 #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,7 @@
 # When viewing the details page for a location, there is an 'Edit' link
 # at the bottom of the page that takes you to the corresponding location
 # in the admin interface. Below, specify the URL for your Admin site.
-admin_site: http://ohana-api-demo.herokuapp.com/admin
+admin_site: https://ohana-api-demo.herokuapp.com/admin
 
 ##########################
 #

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -64,4 +64,4 @@ echo "Pushing code to Heroku now. This will take a few minutes..."
 git push heroku master
 
 echo "All done pushing code."
-echo "You can now visit your site at http://$APP_NAME.herokuapp.com"
+echo "You can now visit your site at https://$APP_NAME.herokuapp.com"


### PR DESCRIPTION
Use the same setup as ohana-api, and clean up application.example.yml.

Use https in documentation that refers to demo sites.