### PR TITLE
Add more guidance on how to manage Ohana git repos

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -2,6 +2,25 @@
 
 Make sure you've [installed](https://github.com/codeforamerica/ohana-web-search/blob/master/INSTALL.md) the app first.
 
+## Prepare your repository
+
+Assuming you have cloned your initial repository from `codeforamerica/ohana-web-search`, rename the default [remote][remote] from `origin` to `codeforamerica`. The `codeforamerica` remote can be used to synchronize your local copy with upstream changes using `git merge codeforamerica/master` or `git rebase codeforamerica/master`.
+
+    git remote rename origin codeforamerica
+
+[Create a new repository][repo] where you will keep your customized version of `ohana-web-search`. This repository can be called anything you like, e.g. `mycity-ohana-web-search`. Make sure you do not add a `.gitignore`, `README`, or `LICENSE` file to the new repository during this step since you will be pushing the contents of the cloned `codeforamerica` repository there shortly.
+
+Add your newly created repository as the `origin` remote by following the on-screen instructions. The command will look something like this:
+
+    git remote add origin git@gitub.com:MYORG/MY-OHANA-WEB-REPO.git
+
+You can now push your clone of `ohana-web-search` to `origin`:
+
+    git push origin master
+
+[remote]: https://help.github.com/categories/managing-remotes/
+[repo]: https://help.github.com/articles/create-a-repo/
+
 ## Environment variables
 Inside the `config` folder, you will find a file named `application.yml`.
 Read through the documentation to learn how you can customize the app to suit

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 ## Install Prerequisites
 
 Before you can run Ohana Web Search, you'll need to have the following software
-packages installed on your computer: Git, Ruby 2.1+, RVM, and PhantomJS.
+packages installed on your computer: Git, Ruby 2.2+, RVM, and PhantomJS.
 If you're on a Linux machine, you'll also need Node.js.
 
 If you already have all of the prerequisites installed, you can go straight
@@ -24,7 +24,7 @@ install the following tools manually:
 
 ## Install Ohana Web Search
 
-Clone it on your computer and navigate to the project's directory:
+Clone the `codeforamerica/ohana-web-search` repository and navigate to the project's directory:
 
     git clone git@github.com:codeforamerica/ohana-web-search.git
     cd ohana-web-search


### PR DESCRIPTION
I've updated the docs a bit as discussed in #801. I also threw in an update to refer to Ruby 2.2 instead of Ruby 2.1 due to the updates in 83d7f7625b8c6496d78a8d907240f5d60be41270