### PR TITLE
Ignore PhantomJS SSL errors on OS X 10.10.3

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,7 @@ Capybara.configure do |config|
 end
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: false)
+  Capybara::Poltergeist::Driver.new(app, js_errors: false, phantomjs_options: ['--ignore-ssl-errors=yes'])
 end
 
 Capybara.add_selector(:rel) do


### PR DESCRIPTION
Starting with OS X 10.10.3, there seems to be an SSL issue that prevents tools like PhantomJS from connecting to HTTPS URLs. This was causing the translation specs to fail because Google makes a call to https://translate.googleapis.com, but PhantomJS is not able to connect to that URL.

I tried stubbing the request as a workaround, but that didn't work. Fortunately, Poltergeist provides an option to ignore SSL errors encountered by PhantomJS. Enabling this option allows the tests to pass on 10.10.3.

Note that this is not an issue on Linux or on OS X versions lower than 10.10.3.