### PR TITLE
Lock requirejs-rails to 0.9.5 due to bug in 0.9.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'font-awesome-rails'
 gem 'uglifier'
 
 # For enabling requirejs-style AMD scripts in the asset pipeline.
-gem 'requirejs-rails', '~> 0.9.2'
+gem 'requirejs-rails', '= 0.9.5'
 
 # For HAML HTML view templates.
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
     rb-kqueue (0.2.3)
       ffi (>= 0.5.0)
     ref (1.0.5)
-    requirejs-rails (0.9.6)
+    requirejs-rails (0.9.5)
       railties (>= 3.1.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -371,7 +371,7 @@ DEPENDENCIES
   rack-rewrite (~> 1.5.0)
   rails (~> 4.2)
   rails_12factor
-  requirejs-rails (~> 0.9.2)
+  requirejs-rails (= 0.9.5)
   rspec-rails (~> 3.1)
   rubocop
   sass-rails (~> 5.0.1)


### PR DESCRIPTION
During deployment to Heroku,
`rake requirejs:precompile:all RAILS_ENV=production RAILS_GROUPS=assets`
fails with `NoMethodError: undefined method '[]' for nil:NilClass` due
to a breaking change in requirejs-rails 0.9.6.

The last time I updated the gem, I neglected to push to Heroku, and
therefore didn't know about this issue.

Deployment works fine with 0.9.5, so I'm reverting and locking it
there until a new requirejs-rails release comes out.

Closes #811.