### PR TITLE
Schema org fixes

### DIFF
--- a/app/helpers/name_format_helper.rb
+++ b/app/helpers/name_format_helper.rb
@@ -12,8 +12,10 @@ module NameFormatHelper
   # @param location [Sawyer::Resource] Location Hash returned by API wrapper.
   # @return [String] The location's name wrapped in a span element.
   def name_content_for(location)
-    content_tag 'span', itemprop: 'name' do
-      location.name
+    content_tag 'span', itemprop: 'legalName' do
+      content_tag 'span', itemprop: 'name' do
+        location.name
+      end
     end
   end
 

--- a/app/helpers/name_format_helper.rb
+++ b/app/helpers/name_format_helper.rb
@@ -12,7 +12,7 @@ module NameFormatHelper
   # @param location [Sawyer::Resource] Location Hash returned by API wrapper.
   # @return [String] The location's name wrapped in a span element.
   def name_content_for(location)
-    content_tag 'span', itemprop: 'legalName' do
+    content_tag 'span', itemprop: 'name' do
       location.name
     end
   end

--- a/app/views/component/detail/_website.html.haml
+++ b/app/views/component/detail/_website.html.haml
@@ -5,6 +5,5 @@
   %section.website.icon-text-block
     %i.fa.fa-external-link-square
     %span
-      %a{ href: website, target: '_blank' }
-        %span{ itemprop: 'url' }
-          = format_url(website)
+      %a{ href: website, target: '_blank', itemprop: 'url' }
+        = format_url(website)

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -9,7 +9,7 @@
           %header
             %hgroup
               %h1.name
-                %a{ href: (location.organization.name == location.name) ? "#{location_path([location.slug], request.query_parameters)}" : "#{location_path([location.organization.slug, location.slug], request.query_parameters)}", name: "#{location.id}", itemprop: 'url' }
+                %a{ href: (location.organization.name == location.name) ? "#{location_path([location.slug], request.query_parameters)}" : "#{location_path([location.organization.slug, location.slug], request.query_parameters)}", name: "#{location.id}" }
                   = superscript_ordinals(full_name_content_for(location))
 
               - if (location.organization.name) && (location.organization.name != location.name)

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -9,7 +9,7 @@
           %header
             %hgroup
               %h1.name
-                %a{ href: (location.organization.name == location.name) ? "#{location_path([location.slug], request.query_parameters)}" : "#{location_path([location.organization.slug, location.slug], request.query_parameters)}", name: "#{location.id}", itemprop: 'name' }
+                %a{ href: (location.organization.name == location.name) ? "#{location_path([location.slug], request.query_parameters)}" : "#{location_path([location.organization.slug, location.slug], request.query_parameters)}", name: "#{location.id}", itemprop: 'url' }
                   = superscript_ordinals(full_name_content_for(location))
 
               - if (location.organization.name) && (location.organization.name != location.name)


### PR DESCRIPTION
Google's [structured data testing tool](https://developers.google.com/structured-data/testing-tool/) was returning a URL for the `name` property for the `/locations` URL on our Ohana Web Search instance. These changes should fix things.