### PR TITLE
Add gems to assist in profiling app performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,11 @@ group :development do
   gem 'spring-commands-rspec'
   # Required by spring to turn on event-based file system listening.
   gem 'spring-watcher-listen'
+
+  # For profiling the app's performance and memory usage.
+  gem 'derailed'
+  gem 'rack-mini-profiler'
+  gem 'flamegraph'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
+    benchmark-ips (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -79,6 +80,14 @@ GEM
       safe_yaml (~> 1.0.0)
     dalli (2.7.4)
     debug_inspector (0.0.2)
+    derailed (0.1.0)
+      derailed_benchmarks
+    derailed_benchmarks (1.0.1)
+      benchmark-ips (~> 2)
+      get_process_mem (~> 0)
+      memory_profiler (~> 0)
+      rack (~> 1)
+      rake (~> 10)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.24)
@@ -93,11 +102,17 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.1.1)
       faraday (~> 0.8)
+    fast_stack (0.1.0)
+      rake
+      rake-compiler
     ffi (1.9.6)
     figaro (1.1.1)
       thor (~> 0.14)
+    flamegraph (0.1.0)
+      fast_stack
     font-awesome-rails (4.3.0.0)
       railties (>= 3.2, < 5.0)
+    get_process_mem (0.2.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     google-api-client (0.8.6)
@@ -168,6 +183,7 @@ GEM
       mime-types (>= 1.16, < 3)
     memcachier (0.0.2)
     memoist (0.12.0)
+    memory_profiler (0.9.4)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
@@ -193,6 +209,8 @@ GEM
     rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-mini-profiler (0.9.7)
+      rack (>= 1.1.3)
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -216,6 +234,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.4.2)
+    rake-compiler (0.9.5)
+      rake
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -333,9 +353,11 @@ DEPENDENCIES
   compass-rails (~> 2.0.4)
   coveralls
   dalli (~> 2.7.1)
+  derailed
   email_spec (~> 1.6.0)
   faraday-http-cache (~> 1.0)
   figaro
+  flamegraph
   font-awesome-rails
   google-api-client (~> 0.8.1)
   haml-lint
@@ -350,6 +372,7 @@ DEPENDENCIES
   puma
   quiet_assets
   rack-cache (~> 1.2)
+  rack-mini-profiler
   rack-rewrite (~> 1.5.0)
   rails_12factor
   railties (~> 4.2)
@@ -364,3 +387,6 @@ DEPENDENCIES
   vcr (~> 2.9.0)
   webmock (~> 1.20)
   yard
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Why:
To allow developers to measure the performance and memory usage of the app.

Further reading:
http://www.nateberkopec.com/2015/08/05/rack-mini-profiler-the-secret-weapon.html

https://github.com/schneems/derailed_benchmarks