### PR TITLE
Use master branch of VCR gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :test do
   gem 'coveralls', require: false
   gem 'capybara', '~> 2.4'
   gem 'poltergeist'
-  gem 'vcr', '~> 3.0'
+  gem 'vcr', git: 'https://github.com/vcr/vcr.git'
   gem 'webmock', '~> 1.20'
   gem 'email_spec', '~> 1.6.0'
   gem 'haml-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/vcr/vcr.git
+  revision: cc57fc4c6da01c37ecb5700040a5eeda5633e12a
+  specs:
+    vcr (3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -333,7 +339,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    vcr (3.0.0)
     webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -387,7 +392,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen
   uglifier
-  vcr (~> 3.0)
+  vcr!
   webmock (~> 1.20)
   yard
 


### PR DESCRIPTION
Why:
Version 3.0.0 introduced a bug when VCR.turn_off! is called. See https://github.com/vcr/vcr/pull/516

The bug is fixed on the master branch, but a new version hasn't been published to rubygems yet.