### PR TITLE
Updated rack-cache 1.6.0 to 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
-    rack-cache (1.6.0)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-mini-profiler (0.9.8)
       rack (>= 1.1.3)


### PR DESCRIPTION
Ruby no longer supports rack-cache 1.6.0: https://rubygems.org/gems/rack-cache/versions/1.6.0