### PR TITLE
Update results page translation spec

### DIFF
--- a/spec/features/general/translate_spec.rb
+++ b/spec/features/general/translate_spec.rb
@@ -42,7 +42,7 @@ feature 'page translation', :js do
       delay
       find(:css, '#button-search').click
       delay # give Google Translate a chance to translate page
-      expect(page).to have_content('Encuentre') # 'Encuentre' = 'Find'
+      expect(page).to have_content('Encuentra') # 'Encuentra' = 'Find'
     end
   end
 


### PR DESCRIPTION
**Why**:
Google's Spanish translation of the English word "Find" was updated from "Encuentre" to "Encuentra". The spec was looking for the former.

**How**:
Update the expectation to look for "Encuentra"

Closes #825