### PR TITLE
Replace Mandrill with SendGrid

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,7 +1,7 @@
 class StatusController < ApplicationController
   def check_status
     response_hash = {}
-    response_hash[:dependencies] = %w(Mandrill Memcachier)
+    response_hash[:dependencies] = %w(SendGrid Memcachier)
     response_hash[:status] = everything_ok? ? 'OK' : 'NOT OK'
     response_hash[:updated] = Time.zone.now.to_i
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,9 +41,9 @@ Rails.application.configure do
 
   #  config.action_mailer.smtp_settings = {
   #   :port =>           '587',
-  #   :address =>        'smtp.mandrillapp.com',
-  #   :user_name =>      ENV['MANDRILL_USERNAME'],
-  #   :password =>       ENV['MANDRILL_APIKEY'],
+  #   :address =>        'smtp.sendgrid.net',
+  #   :user_name =>      ENV['SENDGRID_USERNAME'],
+  #   :password =>       ENV['SENDGRID_APIKEY'],
   #   :domain =>         'heroku.com',
   #   :authentication => :plain
   #  }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,8 @@ Rails.application.configure do
   # --------------------------------------------------------------------------
 
   # --------------------------------------------------------------------------
-  # EMAIL DELIVERY SETUP WITH MANDRILL ON HEROKU
-  # https://devcenter.heroku.com/articles/mandrill
+  # EMAIL DELIVERY SETUP WITH SENDGRID ON HEROKU
+  # https://devcenter.heroku.com/articles/sendgrid
   # ----------------------------------------------
 
   config.action_mailer.default_url_options = { host: ENV['CANONICAL_URL'] }
@@ -95,11 +95,12 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     port:           '587',
-    address:        'smtp.mandrillapp.com',
-    user_name:      ENV['MANDRILL_USERNAME'],
-    password:       ENV['MANDRILL_APIKEY'],
+    address:        'smtp.sendgrid.net',
+    user_name:      ENV['SENDGRID_USERNAME'],
+    password:       ENV['SENDGRID_PASSWORD'],
     domain:         'heroku.com',
-    authentication: :plain
+    authentication: :plain,
+    enable_starttls_auto: true
   }
   # ---------------------------------------------------------------------------
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
   # --------------------------------------------------------------------------
 
   # --------------------------------------------------------------------------
-  # EMAIL DELIVERY SETUP WITH MANDRILL ON HEROKU
-  # https://devcenter.heroku.com/articles/mandrill
+  # EMAIL DELIVERY SETUP WITH SENDGRID ON HEROKU
+  # https://devcenter.heroku.com/articles/sendgrid
   # ----------------------------------------------
 
   config.action_mailer.default_url_options = { host: ENV['CANONICAL_URL'] }
@@ -55,11 +55,12 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     port:           '587',
-    address:        'smtp.mandrillapp.com',
-    user_name:      ENV['MANDRILL_USERNAME'],
-    password:       ENV['MANDRILL_APIKEY'],
+    address:        'smtp.sendgrid.net',
+    user_name:      ENV['SENDGRID_USERNAME'],
+    password:       ENV['SENDGRID_PASSWORD'],
     domain:         'heroku.com',
-    authentication: :plain
+    authentication: :plain,
+    enable_starttls_auto: true
   }
   # ---------------------------------------------------------------------------
 

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -53,11 +53,11 @@ heroku config:set SECRET_TOKEN=$token --app $APP_NAME
 
 echo "Getting ready to install add-ons for $APP_NAME"
 
-echo "Installing Mandrill by MailChimp"
-heroku addons:add mandrill --app $APP_NAME
+echo "Installing SendGrid"
+heroku addons:create sendgrid:starter --app $APP_NAME
 
 echo "Installing Memcachier"
-heroku addons:add memcachier --app $APP_NAME
+heroku addons:create memcachier --app $APP_NAME
 
 echo "All done setting up env vars and add-ons."
 echo "Pushing code to Heroku now. This will take a few minutes..."


### PR DESCRIPTION
**Why**:
Mandrill is getting rid of their free Heroku add-on. SendGrid still has a free plan as of today.

Closes #827