### PR TITLE
Update google-api-client to version 0.9.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'kgio'
 gem 'rack-rewrite', '~> 1.5.0'
 
 # For Google translation API.
-gem 'google-api-client', '~> 0.8.6'
+gem 'google-api-client', '~> 0.9'
 
 # App config and ENV variables for heroku.
 gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,10 +31,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     ast (2.3.0)
-    autoparse (0.3.3)
-      addressable (>= 2.3.1)
-      extlib (>= 0.9.15)
-      multi_json (>= 1.0.0)
     benchmark-ips (2.5.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -101,7 +97,6 @@ GEM
       mail (~> 2.6.3)
     erubis (2.7.0)
     execjs (2.6.0)
-    extlib (0.9.16)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.0)
@@ -115,17 +110,16 @@ GEM
     get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    google-api-client (0.8.6)
-      activesupport (>= 3.2)
+    google-api-client (0.9.9)
       addressable (~> 2.3)
-      autoparse (~> 0.3)
-      extlib (~> 0.9)
-      faraday (~> 0.9)
-      googleauth (~> 0.3)
-      launchy (~> 2.4)
-      multi_json (~> 1.10)
-      retriable (~> 1.4)
-      signet (~> 0.6)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+      thor (~> 0.19)
     googleauth (0.5.1)
       faraday (~> 0.9)
       jwt (~> 1.4)
@@ -156,6 +150,8 @@ GEM
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
     htmlentities (4.3.4)
+    httpclient (2.8.0)
+    hurley (0.2)
     i18n (0.7.0)
     json (1.8.3)
     jwt (1.5.4)
@@ -235,9 +231,11 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    representable (2.3.0)
+      uber (~> 0.0.7)
     requirejs-rails (0.9.5)
       railties (>= 3.1.1)
-    retriable (1.4.1)
+    retriable (2.1.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -276,7 +274,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.7.0)
-    signet (0.7.2)
+    signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (~> 1.5)
@@ -311,6 +309,7 @@ GEM
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uber (0.0.15)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.0.5)
@@ -344,7 +343,7 @@ DEPENDENCIES
   figaro
   flamegraph
   font-awesome-rails
-  google-api-client (~> 0.8.6)
+  google-api-client (~> 0.9)
   haml-rails
   haml_lint
   kaminari
@@ -374,5 +373,8 @@ DEPENDENCIES
   webmock (~> 2.1)
   yard
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.10.6
+   1.12.4

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,10 +4,9 @@ class LocationsController < ApplicationController
 
   def index
     # To enable Google Translation of keywords,
-    # uncomment lines 9-11 and 19, and see documentation for
+    # uncomment lines 9-10 and 18, and see documentation for
     # GOOGLE_TRANSLATE_API_KEY in config/application.example.yml.
-    # translator = KeywordTranslator.new(
-    #   params[:keyword], current_language, 'en', 'text')
+    # translator = KeywordTranslator.new(params[:keyword], current_language, 'en')
     # params[:keyword] = translator.translated_keyword
 
     locations = Location.search(params)


### PR DESCRIPTION
**Why**: To use the latest and greatest, and to take advantage of the
updated wrapper code, which is more idiomatic and easier to work with.