### PR TITLE
Replace links to ohanapi.org with API GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/codeforamerica/ohana-web-search.png?branch=master)](https://travis-ci.org/codeforamerica/ohana-web-search) [![Coverage Status](https://coveralls.io/repos/codeforamerica/ohana-web-search/badge.png?branch=master)](https://coveralls.io/r/codeforamerica/ohana-web-search?branch=master) [![Dependency Status](https://gemnasium.com/codeforamerica/ohana-web-search.png)](https://gemnasium.com/codeforamerica/ohana-web-search) [![Code Climate](https://codeclimate.com/github/codeforamerica/ohana-web-search.png)](https://codeclimate.com/github/codeforamerica/ohana-web-search)
 
-Ohana Web Search is the web-based search portion of the [Ohana](http://ohanapi.org) project. It requires connecting to your own instance of [Ohana API](https://github.com/codeforamerica/ohana-api), which will provide the data to Ohana Web Search.
+Ohana Web Search is the web-based search portion of the Ohana project. It requires connecting to your own instance of [Ohana API](https://github.com/codeforamerica/ohana-api), which will provide the data to Ohana Web Search.
 
 This project was developed by [Code for America's 2013 San Mateo County, CA,](http://codeforamerica.org/2013-partners/san-mateo-county/) fellowship team. Thanks to a [grant from the Knight Foundation](http://www.knightfoundation.org/grants/201447979/), [@monfresh](https://github.com/monfresh), [@spara](https://github.com/spara), and [@anselmbradford](https://github.com/anselmbradford) will continue to push code in 2014.
 

--- a/app/views/component/about/_about.html.haml
+++ b/app/views/component/about/_about.html.haml
@@ -7,7 +7,7 @@
 
     %p
       This project is part of the development of the
-      = link_to('Ohana API', 'http://ohanapi.org', target: '_blank') + ','
+      = link_to('Ohana API', 'https://github.com/codeforamerica/ohana-api', target: '_blank') + ','
       an open source database of community services.
 
     %p

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -12,7 +12,6 @@
   %p.get-this-app
     %i.fa.fa-bullhorn
     %a{ href: 'https://github.com/codeforamerica/ohana-web-search' } Get this app
-    for your city or
-    #{link_to 'view project details', 'http://ohanapi.org'}.
+    for your city.
 
   #google-translate-container

--- a/spec/features/pages/homepage_spec.rb
+++ b/spec/features/pages/homepage_spec.rb
@@ -54,13 +54,6 @@ describe 'Home page footer elements' do
     visit '/'
   end
 
-  it 'includes a link to ohanapi.org' do
-    within('#app-footer') do
-      expect(find_link('view project details')[:href]).
-        to eq('http://ohanapi.org')
-    end
-  end
-
   it 'includes a link to codeforamerica.org' do
     within('#app-footer') do
       expect(find_link('Code for America')[:href]).


### PR DESCRIPTION
**Why**: We never renewed the domain registration, and someone else bought it.