### PR TITLE
Fix spec for "Edit" link to use SETTINGS

### DIFF
--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -233,9 +233,8 @@ feature 'location details' do
     end
 
     it 'points to the corresponding location in the admin site' do
-      admin_site = 'http://ohana-api-demo.herokuapp.com/admin'
       expect(page).
-        to have_link('Edit', href: "#{admin_site}/locations/example-location")
+        to have_link('Edit', href: "#{SETTINGS[:admin_site]}/locations/example-location")
     end
 
     it 'includes rel=nofollow' do


### PR DESCRIPTION
This PR updates the spec that checks for an "Edit" link on location pages to use the value of `SETTINGS[:admin_site]` instead of hard-coding the "http://ohana-api-demo.herokuapp.com/admin" URL.