### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,6 @@ gem 'sprockets', '~> 3.7.1'
 gem 'uglifier'
 gem 'webpacker', '~> 3.2'
 
-group :production, :staging do
-  # Enables serving assets in production and setting logger to standard out.
-  gem 'rails_12factor'
-end
-
 # dev and debugging tools
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,11 +239,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.4)
     railties (5.1.6)
       actionpack (= 5.1.6)
       activesupport (= 5.1.6)
@@ -399,7 +394,6 @@ DEPENDENCIES
   rack-mini-profiler
   rack-rewrite (~> 1.5.0)
   rails-controller-testing
-  rails_12factor
   railties (~> 5.1.6)
   reek
   rspec-rails (~> 3.1)

--- a/app.json
+++ b/app.json
@@ -54,6 +54,14 @@
     "RAILS_ENV": {
       "required": true
     },
+    "RAILS_LOG_TO_STDOUT": {
+      "required": true,
+      "value": "true"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "required": true,
+      "value": "true"
+    },
     "SECRET_TOKEN": {
       "required": true
     },

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -148,6 +148,8 @@ production:
   # GOOGLE_TRANSLATE_API_KEY: Your_API_Key
   OHANA_API_ENDPOINT: https://ohana-api-demo.herokuapp.com/api
   # OHANA_API_TOKEN: changeme
+  RAILS_LOG_TO_STDOUT: 'true'
+  RAILS_SERVE_STATIC_FILES: 'true'
 
 ###############################################################################
 #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,10 @@ Rails.application.configure do
   # https://devcenter.heroku.com/articles/rack-cache-memcached-rails31
   # ------------------------------------------------------------------
 
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=2592000'
+  }
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
@@ -80,7 +83,6 @@ Rails.application.configure do
     metastore:   client,
     entitystore: client
   }
-  config.static_cache_control = 'public, max-age=2592000'
   # --------------------------------------------------------------------------
 
   # --------------------------------------------------------------------------
@@ -148,9 +150,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
@@ -163,4 +162,9 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+  if ENV['RAILS_LOG_TO_STDOUT'] == 'true'
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -17,7 +17,10 @@ Rails.application.configure do
   # https://devcenter.heroku.com/articles/rack-cache-memcached-rails31
   # ------------------------------------------------------------------
 
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'] == 'true'
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=2592000'
+  }
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
@@ -37,7 +40,6 @@ Rails.application.configure do
     metastore:   client,
     entitystore: client
   }
-  config.static_cache_control = 'public, max-age=2592000'
   # --------------------------------------------------------------------------
 
   # --------------------------------------------------------------------------
@@ -105,9 +107,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
@@ -120,4 +119,9 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+  if ENV['RAILS_LOG_TO_STDOUT'] == 'true'
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -47,6 +47,12 @@ heroku config:set DOMAIN_NAME=$APP_NAME.herokuapp.com --app $APP_NAME
 echo "Setting OHANA_API_ENDPOINT"
 heroku config:set OHANA_API_ENDPOINT=$OHANA_API_ENDPOINT --app $APP_NAME
 
+echo "Setting RAILS_LOG_TO_STDOUT to true"
+heroku config:set RAILS_LOG_TO_STDOUT=true --app $APP_NAME
+
+echo "Setting RAILS_SERVE_STATIC_FILES to true"
+heroku config:set RAILS_SERVE_STATIC_FILES=true --app $APP_NAME
+
 echo "Setting SECRET_TOKEN"
 token=$(python -c 'import uuid; print uuid.uuid4()')
 heroku config:set SECRET_TOKEN=$token --app $APP_NAME


### PR DESCRIPTION
**Why**: The functionality is provided by default in Rails 5 as long as certain settings are configured properly.
Reference: https://github.com/heroku/rails_12factor#migrating-to-rails-5