### PR TITLE
Replace poltergeist with webdrivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,6 @@ jobs:
             - ~/.cache/yarn
 
       - run:
-          name: Install phantomjs
-          command: |
-            sudo curl --output /tmp/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
-            sudo chmod ugo+x /tmp/phantomjs
-            sudo ln -sf /tmp/phantomjs /usr/local/bin/phantomjs
-      - run:
           name: Install Code Climate Test Reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,6 @@ RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
 RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y --no-install-recommends yarn
 
-# PhantomJS is required for running tests
-ENV PHANTOMJS_SHA256 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
-
-RUN mkdir /usr/local/phantomjs \
-  && curl -o phantomjs.tar.bz2 -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-  && echo "$PHANTOMJS_SHA256 *phantomjs.tar.bz2" | sha256sum -c - \
-  && tar -xjf phantomjs.tar.bz2 -C /usr/local/phantomjs --strip-components=1 \
-  && rm phantomjs.tar.bz2
-
-RUN ln -s ../phantomjs/bin/phantomjs /usr/local/bin/
-
 WORKDIR /ohana-web-search
 
 COPY Gemfile /ohana-web-search

--- a/Gemfile
+++ b/Gemfile
@@ -44,11 +44,11 @@ group :test do
   gem 'capybara'
   gem 'email_spec'
   gem 'haml_lint'
-  gem 'poltergeist'
   gem 'rails-controller-testing'
   gem 'rubocop'
   gem 'simplecov', require: false
   gem 'vcr'
+  gem 'webdrivers'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,16 +46,17 @@ GEM
     bummr (0.5.0)
       rainbow
       thor
-    capybara (3.16.1)
+    capybara (3.21.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
+      regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    childprocess (1.0.1)
+      rake (< 13.0)
     chunky_png (1.3.10)
-    cliver (0.3.2)
     codeclimate-engine-rb (0.4.1)
       virtus (~> 1.0)
     coderay (1.1.2)
@@ -196,7 +197,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     ohanakapa (1.1.3)
       sawyer (~> 0.8)
@@ -204,14 +205,10 @@ GEM
     parallel (1.16.2)
     parser (2.6.2.0)
       ast (~> 2.4.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     psych (3.1.0)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     puma (3.12.1)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
     rack-mini-profiler (1.0.2)
@@ -247,7 +244,7 @@ GEM
       parser (>= 2.5.0.0, < 2.7, != 2.5.1.1)
       psych (~> 3.1.0)
       rainbow (>= 2.0, < 4.0)
-    regexp_parser (1.3.0)
+    regexp_parser (1.5.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -282,6 +279,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.9.0)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -293,6 +291,9 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.9.0)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -336,6 +337,10 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webdrivers (3.9.4)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -344,9 +349,6 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.18)
@@ -377,7 +379,6 @@ DEPENDENCIES
   letter_opener
   memcachier
   ohanakapa (~> 1.1.1)
-  poltergeist
   puma
   rack-cache (~> 1.2)
   rack-mini-profiler
@@ -396,6 +397,7 @@ DEPENDENCIES
   stackprof
   uglifier
   vcr
+  webdrivers
   webmock
   webpacker (~> 4.0)
   yard

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,6 @@ packages installed on your computer:
 - Git
 - Ruby 2.3+
 - RVM (or other Ruby version manager)
-- PhantomJS
 - Yarn 0.25.2+
 - Node.js 6.0.0+
 
@@ -42,13 +41,12 @@ next step. Otherwise, there are two ways you can install the tools:
 - If you're on a Mac, the easiest way to install all the tools is to use
 @monfresh's [laptop] script.
 
-- Install everything manually: [Build tools], [Ruby with RVM], [phantomjs], and
+- Install everything manually: [Build tools], [Ruby with RVM], and
 [Node.js][node] (Linux only).
 
 [laptop]: https://github.com/monfresh/laptop
 [Build tools]: https://github.com/codeforamerica/howto/blob/master/Build-Tools.md
 [Ruby with RVM]: https://github.com/codeforamerica/howto/blob/master/Ruby.md
-[phantomjs]: https://github.com/jonleighton/poltergeist#installing-phantomjs
 [node]: https://github.com/codeforamerica/howto/blob/master/Node.js.md
 
 ### Install the dependencies and set the default environment variables:

--- a/spec/cassettes/Search_summary/when_visiting_search_results_page_that_does_not_have_results.yml
+++ b/spec/cassettes/Search_summary/when_visiting_search_results_page_that_does_not_have_results.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:38:45 GMT
+      - Mon, 27 May 2019 21:20:09 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 0e6b8fac-e166-41c8-be7c-f62f5a100369
+      - 9cb0be93-724c-48e5-aea6-395bcc227fd1
       X-Runtime:
-      - '0.018452'
+      - '0.016868'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -57,5 +57,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:38:45 GMT
+  recorded_at: Mon, 27 May 2019 21:20:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/Search_summary/when_visiting_search_results_page_that_has_results.yml
+++ b/spec/cassettes/Search_summary/when_visiting_search_results_page_that_has_results.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:38:45 GMT
+      - Mon, 27 May 2019 21:20:09 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f6bc9f50-7a8b-45fb-9489-72c6b6896ccd
+      - '08fedba2-2694-4052-9f68-5fd003706d2d'
       X-Runtime:
-      - '0.090181'
+      - '0.019257'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:38:45 GMT
+  recorded_at: Mon, 27 May 2019 21:20:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/Site_Pages/when_visiting_results_page_directly.yml
+++ b/spec/cassettes/Site_Pages/when_visiting_results_page_directly.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:16 GMT
+      - Mon, 27 May 2019 21:20:08 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - ef7c4fb9-182d-48e1-9159-c5c079744752
+      - 47c55e3d-1444-43e8-b753-f6ce42aa86f0
       X-Runtime:
-      - '0.024678'
+      - '0.023473'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:16 GMT
+  recorded_at: Mon, 27 May 2019 21:20:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/StatusController/GET_/_well-known/status/when_everything_is_fine/returns_success.yml
+++ b/spec/cassettes/StatusController/GET_/_well-known/status/when_everything_is_fine/returns_success.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:24 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - faae7e13-5cd5-4df5-9733-0b55f7e4090a
+      - c766265b-399c-4c12-bcb2-a3d21a57fcd0
       X-Runtime:
-      - '0.066470'
+      - '0.050627'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -73,7 +73,7 @@ http_interactions:
         SERVICES","Outpatient Care","Community Clinics","Medicare"],"languages":[],"name":"San
         Mateo Free Medical Clinic","required_documents":[],"service_areas":["Belmont","Burlingame"],"status":"active","website":null,"wait_time":"Varies.","updated_at":"2014-10-29T10:08:12.260-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:24 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?keyword=food
@@ -112,15 +112,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:24 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 4b62376d-ef3c-4270-8a87-e71a583719a0
+      - 3059f21a-3298-45a4-be3c-4e838c7edbb1
       X-Runtime:
-      - '0.042352'
+      - '0.021413'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -148,5 +148,5 @@ http_interactions:
         266-2594","number_type":"fax","vanity_number":null},{"id":34,"department":null,"extension":null,"number":"650
         266-4594","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:24 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_a_Google_Maps_directions_link.yml
+++ b/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_a_Google_Maps_directions_link.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:20 GMT
+      - Mon, 27 May 2019 21:19:48 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 7ba79d17-6a92-4a36-8fe4-1cfcd795182a
+      - c79db32d-2503-4d1c-bb9c-44dbd61c0cdb
       X-Runtime:
-      - '0.102953'
+      - '0.033407'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         in.","interpretation_services":null,"keywords":[],"languages":[],"name":"Service
         with blank fields","required_documents":[],"service_areas":[],"status":"defunct","website":null,"wait_time":null,"updated_at":"2014-10-29T10:08:12.309-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:20 GMT
+  recorded_at: Mon, 27 May 2019 21:19:48 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_the_physical_address_header.yml
+++ b/spec/cassettes/address_formatting/when_no_address_elements_are_present/does_not_include_the_physical_address_header.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:20 GMT
+      - Mon, 27 May 2019 21:19:49 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 0a707930-d736-4bd1-9b82-d54878448126
+      - 241945aa-abcb-4bbf-a4de-956ceb37a50c
       X-Runtime:
-      - '0.053187'
+      - '0.034206'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         in.","interpretation_services":null,"keywords":[],"languages":[],"name":"Service
         with blank fields","required_documents":[],"service_areas":[],"status":"defunct","website":null,"wait_time":null,"updated_at":"2014-10-29T10:08:12.309-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:20 GMT
+  recorded_at: Mon, 27 May 2019 21:19:49 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/all_results.yml
+++ b/spec/cassettes/all_results.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:29 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 56148a28-ccf7-4c29-963b-b6149aedfd51
+      - 2306a633-245e-46a6-ad13-ecc0455b770d
       X-Runtime:
-      - '0.025585'
+      - '0.024689'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:29 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/detail_view_map/location_does_not_have_coordinates/does_not_display_a_map.yml
+++ b/spec/cassettes/detail_view_map/location_does_not_have_coordinates/does_not_display_a_map.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:21 GMT
+      - Mon, 27 May 2019 21:20:08 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - a2e52b2f-6a91-499b-80c6-213ac4adcbe9
+      - 6400ac20-9c52-4c86-9959-3809d405ab86
       X-Runtime:
-      - '0.074189'
+      - '0.038468'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         in.","interpretation_services":null,"keywords":[],"languages":[],"name":"Service
         with blank fields","required_documents":[],"service_areas":[],"status":"defunct","website":null,"wait_time":null,"updated_at":"2014-10-29T10:08:12.309-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:21 GMT
+  recorded_at: Mon, 27 May 2019 21:20:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/detail_view_map/location_has_coordinates/displays_a_map.yml
+++ b/spec/cassettes/detail_view_map/location_has_coordinates/displays_a_map.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:21 GMT
+      - Mon, 27 May 2019 21:20:08 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - eb12870d-c2ae-4b71-ad56-7494db04a2d2
+      - bb83682c-26ae-4ccf-8848-808fccadc3a3
       X-Runtime:
-      - '0.089699'
+      - '0.057287'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -124,5 +124,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:21 GMT
+  recorded_at: Mon, 27 May 2019 21:20:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/dynamic/location_details/phone_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/phone_dynamic.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:29 GMT
+      - Mon, 27 May 2019 21:20:08 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - b470e87f-4911-4078-9700-54ca6817f96f
+      - 80dd5b51-7db3-4108-86d5-34f5e2b269b5
       X-Runtime:
-      - '0.089355'
+      - '0.094563'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -123,5 +123,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version:
-  recorded_at: Sun, 17 Mar 2019 17:39:29 GMT
+  recorded_at: Mon, 27 May 2019 21:20:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/dynamic/location_details/phone_type_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/phone_type_dynamic.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:21 GMT
+      - Mon, 27 May 2019 21:19:41 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 58866f19-3529-4c5f-8607-8aff94929762
+      - d68f2cf3-5d2f-4454-8d58-43ce64d369eb
       X-Runtime:
-      - '0.035037'
+      - '0.019173'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"<%= third_general_number_type %>","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version:
-  recorded_at: Sun, 17 Mar 2019 17:39:21 GMT
+  recorded_at: Mon, 27 May 2019 21:19:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/dynamic/location_details/superscript_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/superscript_dynamic.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:38:45 GMT
+      - Mon, 27 May 2019 21:19:42 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 79d96ddb-4c48-4045-aa47-8249830db8d8
+      - e60bc84e-c915-4a44-b3f5-12994e56e516
       X-Runtime:
-      - '0.128134'
+      - '0.066140'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -124,5 +124,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version:
-  recorded_at: Sun, 17 Mar 2019 17:38:46 GMT
+  recorded_at: Mon, 27 May 2019 21:19:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/dynamic/location_details/website_dynamic.yml
+++ b/spec/cassettes/dynamic/location_details/website_dynamic.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:38:45 GMT
+      - Mon, 27 May 2019 21:19:48 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9f9720b4-0496-4dd7-b860-45a185834929
+      - 2f8b633c-14df-48e9-ad96-bd0698298177
       X-Runtime:
-      - '0.365335'
+      - '0.051594'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -124,5 +124,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version:
-  recorded_at: Sun, 17 Mar 2019 17:38:45 GMT
+  recorded_at: Mon, 27 May 2019 21:19:48 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/homepage_search/when_clicking_a_general_link.yml
+++ b/spec/cassettes/homepage_search/when_clicking_a_general_link.yml
@@ -39,15 +39,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:16 GMT
+      - Mon, 27 May 2019 21:20:09 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 04666761-45ea-4f70-bb96-ab078ea82f91
+      - 831c9502-e6e1-4363-bc38-964a8589bf55
       X-Runtime:
-      - '0.034908'
+      - '0.024997'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -86,5 +86,5 @@ http_interactions:
         780-7525","number_type":"voice","vanity_number":null},{"id":2,"department":null,"extension":null,"number":"650
         701-0856","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:16 GMT
+  recorded_at: Mon, 27 May 2019 21:20:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
@@ -37,15 +37,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:16 GMT
+      - Mon, 27 May 2019 21:20:09 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - c9e29c7f-2a69-4513-865f-de281ba24f5d
+      - '0139b119-1ef8-4506-8123-29f6d63870ca'
       X-Runtime:
-      - '0.023775'
+      - '0.015708'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:16 GMT
+  recorded_at: Mon, 27 May 2019 21:20:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_results.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:16 GMT
+      - Mon, 27 May 2019 21:20:09 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 3982e1df-5526-4e1d-93c7-e65237d85467
+      - efe9dd9a-39bc-4a61-9851-8cf832cf715a
       X-Runtime:
-      - '0.032294'
+      - '0.024557'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:16 GMT
+  recorded_at: Mon, 27 May 2019 21:20:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/when_info_box_does_not_have_an_url/does_not_display_the_More_info_link.yml
+++ b/spec/cassettes/info_box/when_info_box_does_not_have_an_url/does_not_display_the_More_info_link.yml
@@ -37,15 +37,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 133283ca-a77a-4e1c-b95b-9b1d645534fa
+      - 27b0064f-b680-4947-81de-71b0ef14a29e
       X-Runtime:
-      - '0.024114'
+      - '0.033701'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/with_keyword_that_doesn_t_match_info_box_synonym.yml
+++ b/spec/cassettes/info_box/with_keyword_that_doesn_t_match_info_box_synonym.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 21453957-26a0-4e7b-a8e6-2cd1ef8be943
+      - ac5a1827-8911-403a-a38f-e18a8246f24f
       X-Runtime:
-      - '0.033244'
+      - '0.036642'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -74,5 +74,5 @@ http_interactions:
         266-2594","number_type":"fax","vanity_number":null},{"id":34,"department":null,"extension":null,"number":"650
         266-4594","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_section_with_a_terminology_id.yml
+++ b/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_section_with_a_terminology_id.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 69ae39f8-e2ee-4d7b-bb59-a54f25c6ae88
+      - d7e9210f-7ebd-4586-8605-ea5a63392e52
       X-Runtime:
-      - '0.029391'
+      - '0.027306'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_the_description_in_a_dd_tag.yml
+++ b/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_the_description_in_a_dd_tag.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 76069eb1-33be-4466-9df9-adec1c4951bf
+      - 6bbe9a6e-6296-451d-af5d-96fcb9694fe7
       X-Runtime:
-      - '0.030842'
+      - '0.022920'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_the_title_in_a_dt_tag.yml
+++ b/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_the_title_in_a_dt_tag.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 238fbff6-be92-4b97-835f-4da0c3ac7203
+      - 33b94819-a477-4232-9d4c-9dd8a9f2cbd1
       X-Runtime:
-      - '0.042214'
+      - '0.026097'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_the_url_when_one_is_present.yml
+++ b/spec/cassettes/info_box/with_keyword_that_matches_info_box_synonym/displays_the_url_when_one_is_present.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 98c0a697-986f-45c9-8883-299dbe386f6d
+      - f210577b-3af2-4fa1-9404-b84638c43694
       X-Runtime:
-      - '0.028788'
+      - '0.021286'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/info_box/with_keyword_that_matches_synonym_from_custom_info_box.yml
+++ b/spec/cassettes/info_box/with_keyword_that_matches_synonym_from_custom_info_box.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:30 GMT
+      - Mon, 27 May 2019 21:20:10 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - a0331223-2b01-4278-9f38-06d054b2486d
+      - df8b4841-ac45-40b3-a316-d1548969d59a
       X-Runtime:
-      - '0.020151'
+      - '0.016248'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -57,5 +57,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:30 GMT
+  recorded_at: Mon, 27 May 2019 21:20:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_Contact_only_includes_department.yml
+++ b/spec/cassettes/location_details/when_Contact_only_includes_department.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:25 GMT
+      - Mon, 27 May 2019 21:20:12 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 1894eeac-973d-4b3f-b653-beb96dd1c254
+      - 6942313a-c441-43bf-be9c-4e0f7e3519b6
       X-Runtime:
-      - '0.062850'
+      - '0.052599'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -64,5 +64,5 @@ http_interactions:
         for Admin Test Location","required_documents":[],"service_areas":["San Mateo
         County"],"status":"inactive","website":null,"wait_time":null,"updated_at":"2014-10-29T10:08:12.381-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:25 GMT
+  recorded_at: Mon, 27 May 2019 21:20:12 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_Contact_only_includes_title.yml
+++ b/spec/cassettes/location_details/when_Contact_only_includes_title.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:24 GMT
+      - Mon, 27 May 2019 21:20:12 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - ec18fb0c-c0be-484a-a23c-8d7088f2b472
+      - 1ab5f455-8cba-4c54-b02f-b3d3dfababe2
       X-Runtime:
-      - '0.072150'
+      - '0.058437'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -99,5 +99,5 @@ http_interactions:
         Oaks Adult Activity Center","required_documents":[],"service_areas":["Colma"],"status":"active","website":null,"wait_time":"No
         wait.","updated_at":"2014-10-29T10:08:11.018-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:24 GMT
+  recorded_at: Mon, 27 May 2019 21:20:12 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_URL_to_details_page_contains_quote_at_the_end/displays_a_not_found_error_message.yml
+++ b/spec/cassettes/location_details/when_URL_to_details_page_contains_quote_at_the_end/displays_a_not_found_error_message.yml
@@ -35,11 +35,11 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 6e6ccf06-7a4b-4821-bb97-9e9d7c15a973
+      - 3a403baa-6f82-4680-89c6-9df5cb771c47
       X-Runtime:
-      - '0.020030'
+      - '0.011712'
       Date:
-      - Sun, 17 Mar 2019 17:39:25 GMT
+      - Mon, 27 May 2019 21:20:13 GMT
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -50,5 +50,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"status":404,"message":"The requested resource could not be found.","documentation_url":"http://codeforamerica.github.io/ohana-api-docs/"}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:25 GMT
+  recorded_at: Mon, 27 May 2019 21:20:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_URL_to_details_page_contains_quote_at_the_end/redirects_to_the_homepage.yml
+++ b/spec/cassettes/location_details/when_URL_to_details_page_contains_quote_at_the_end/redirects_to_the_homepage.yml
@@ -35,11 +35,11 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 0f559ce6-cd92-4360-9b38-f69edd5c0341
+      - 191ee9bb-898c-4a3c-93f4-29b2ea42f30b
       X-Runtime:
-      - '0.015056'
+      - '0.009058'
       Date:
-      - Sun, 17 Mar 2019 17:39:25 GMT
+      - Mon, 27 May 2019 21:20:13 GMT
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -50,5 +50,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"status":404,"message":"The requested resource could not be found.","documentation_url":"http://codeforamerica.github.io/ohana-api-docs/"}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:25 GMT
+  recorded_at: Mon, 27 May 2019 21:20:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:20 GMT
+      - Mon, 27 May 2019 21:19:49 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 89af85ca-5f77-465b-bae0-252322e16d0f
+      - c8d240e2-1826-40dd-b8c3-435d91ae3b01
       X-Runtime:
-      - '0.098790'
+      - '0.059835'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -124,5 +124,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:20 GMT
+  recorded_at: Mon, 27 May 2019 21:19:49 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly/includes_the_location.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly/includes_the_location.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:25 GMT
+      - Mon, 27 May 2019 21:20:12 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 1f446e47-63ed-4d0b-9fae-a7defeb70b13
+      - 4bab7bd7-5c19-48eb-ac53-2b125ef239c6
       X-Runtime:
-      - '0.084991'
+      - '0.070355'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -124,5 +124,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:25 GMT
+  recorded_at: Mon, 27 May 2019 21:20:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly/includes_the_share_via_email_link.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly/includes_the_share_via_email_link.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:25 GMT
+      - Mon, 27 May 2019 21:20:12 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 928e6b83-5ca6-422e-aea7-3ee53f14e901
+      - bbc6690d-d566-41be-88d0-546fc401a8c3
       X-Runtime:
-      - '0.073073'
+      - '0.063928'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -124,5 +124,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:25 GMT
+  recorded_at: Mon, 27 May 2019 21:20:12 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id/displays_an_error_message.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id/displays_an_error_message.yml
@@ -35,11 +35,11 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 46b61db1-0507-4212-a91b-dd2716438be8
+      - aea3cd70-9e8d-417f-bce6-bcab5887555b
       X-Runtime:
-      - '0.009333'
+      - '0.007736'
       Date:
-      - Sun, 17 Mar 2019 17:39:26 GMT
+      - Mon, 27 May 2019 21:20:13 GMT
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -50,5 +50,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"status":404,"message":"The requested resource could not be found.","documentation_url":"http://codeforamerica.github.io/ohana-api-docs/"}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:26 GMT
+  recorded_at: Mon, 27 May 2019 21:20:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id/redirects_to_the_homepage.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_directly_with_invalid_id/redirects_to_the_homepage.yml
@@ -35,11 +35,11 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - bdf6f7ad-92aa-4c1e-8cb9-68b49670fdf9
+      - 897af515-9fb8-4cb8-a69e-ee55696d0162
       X-Runtime:
-      - '0.017839'
+      - '0.010333'
       Date:
-      - Sun, 17 Mar 2019 17:39:26 GMT
+      - Mon, 27 May 2019 21:20:13 GMT
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -50,5 +50,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"status":404,"message":"The requested resource could not be found.","documentation_url":"http://codeforamerica.github.io/ohana-api-docs/"}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:26 GMT
+  recorded_at: Mon, 27 May 2019 21:20:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_the_details_page_is_visited_via_search_results/includes_address_elements.yml
+++ b/spec/cassettes/location_details/when_the_details_page_is_visited_via_search_results/includes_address_elements.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:26 GMT
+      - Mon, 27 May 2019 21:20:12 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - d7d8118d-a927-416f-b6a9-79a435923257
+      - d030e91e-fcce-4885-9a0e-1b7ebced2423
       X-Runtime:
-      - '0.027010'
+      - '0.024657'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,7 +80,7 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:26 GMT
+  recorded_at: Mon, 27 May 2019 21:20:12 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/locations/example-location
@@ -116,15 +116,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:26 GMT
+      - Mon, 27 May 2019 21:20:12 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 6050f70b-ff01-4fc7-9d48-06e19769159e
+      - ca45943d-6ef8-4329-a95b-ea1f8d5c6be1
       X-Runtime:
-      - '0.078213'
+      - '0.057522'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -205,5 +205,5 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:26 GMT
+  recorded_at: Mon, 27 May 2019 21:20:12 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_details/when_you_return_to_the_results_page_from_details_page/displays_the_same_search_results.yml
+++ b/spec/cassettes/location_details/when_you_return_to_the_results_page_from_details_page/displays_the_same_search_results.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:27 GMT
+      - Mon, 27 May 2019 21:20:13 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 15ff3628-6018-421e-9450-9dff52dad19a
+      - 2800ab6d-7253-4444-a41d-ffffcacc9d6c
       X-Runtime:
-      - '0.030320'
+      - '0.024731'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,7 +80,7 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:27 GMT
+  recorded_at: Mon, 27 May 2019 21:20:14 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/locations/example-location
@@ -116,15 +116,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:27 GMT
+      - Mon, 27 May 2019 21:20:14 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - cc94fd1e-3bac-42f6-b271-7973e07dcb53
+      - 3b6fc25c-0c8f-4221-af1e-09c448559654
       X-Runtime:
-      - '0.081439'
+      - '0.076523'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -205,7 +205,7 @@ http_interactions:
         Photos Fax","extension":null,"number":"789-456-1230","number_type":"fax","vanity_number":null},{"id":59,"department":"Passport
         Help via SMS","extension":null,"number":"650-222-5555","number_type":"sms","vanity_number":null}],"regular_schedules":[{"weekday":1,"opens_at":"2000-01-01T08:00:00.000Z","closes_at":"2000-01-01T12:00:00.000Z"},{"weekday":1,"opens_at":"2000-01-01T14:00:00.000Z","closes_at":"2000-01-01T16:00:00.000Z"},{"weekday":3,"opens_at":"2000-01-01T10:00:00.000Z","closes_at":"2000-01-01T15:00:00.000Z"}],"holiday_schedules":[{"closed":true,"start_date":"0001-01-01","end_date":"0001-01-01","opens_at":null,"closes_at":null}]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:27 GMT
+  recorded_at: Mon, 27 May 2019 21:20:14 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example
@@ -241,15 +241,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:28 GMT
+      - Mon, 27 May 2019 21:20:16 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - ef0206b8-3e97-4db9-9ed5-c3712d80ab14
+      - 18feb49f-d65d-4ba3-bed1-1631636f5779
       X-Runtime:
-      - '0.030566'
+      - '0.026516'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -286,5 +286,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:28 GMT
+  recorded_at: Mon, 27 May 2019 21:20:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_service_details/when_service_element_status_is_present/includes_defunct_status_notice.yml
+++ b/spec/cassettes/location_service_details/when_service_element_status_is_present/includes_defunct_status_notice.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:22 GMT
+      - Mon, 27 May 2019 21:20:19 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 937bf118-39f9-4a58-abc2-f93f41c595f3
+      - c0fc4c1d-8fdf-4959-a96c-48cc6c621043
       X-Runtime:
-      - '0.068150'
+      - '0.035029'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         in.","interpretation_services":null,"keywords":[],"languages":[],"name":"Service
         with blank fields","required_documents":[],"service_areas":[],"status":"defunct","website":null,"wait_time":null,"updated_at":"2014-10-29T10:08:12.309-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:22 GMT
+  recorded_at: Mon, 27 May 2019 21:20:19 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/location_service_details/when_service_element_status_is_present/includes_inactive_status_notice.yml
+++ b/spec/cassettes/location_service_details/when_service_element_status_is_present/includes_inactive_status_notice.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:22 GMT
+      - Mon, 27 May 2019 21:20:19 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - fc8532b7-3d4f-4c36-a3d5-cda18a8f66ed
+      - fb350f93-4040-473f-9fe0-932e538ee63d
       X-Runtime:
-      - '0.051736'
+      - '0.046129'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -64,5 +64,5 @@ http_interactions:
         for Admin Test Location","required_documents":[],"service_areas":["San Mateo
         County"],"status":"inactive","website":null,"wait_time":null,"updated_at":"2014-10-29T10:08:12.381-07:00","categories":[],"contacts":[],"phones":[],"regular_schedules":[],"holiday_schedules":[]}]}'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:22 GMT
+  recorded_at: Mon, 27 May 2019 21:20:19 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/page_translation/results_page_is_translated/displays_translated_contents.yml
+++ b/spec/cassettes/page_translation/results_page_is_translated/displays_translated_contents.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:37:48 GMT
+      - Wed, 29 May 2019 02:32:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 272cc561-678b-4d8d-aaca-e8b50c78ce9e
+      - 0101fec8-b907-4266-8830-080ddce445cd
       X-Runtime:
-      - '0.033966'
+      - '0.199573'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:37:48 GMT
+  recorded_at: Wed, 29 May 2019 02:32:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/displays_an_appropriate_search_summary.yml
+++ b/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/displays_an_appropriate_search_summary.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:06 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - ab6f70f0-8d5e-49de-92c7-152d3ad8f063
+      - b369b30a-a50c-4a67-b851-679bb118c281
       X-Runtime:
-      - '0.028209'
+      - '0.021493'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,5 +78,5 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/does_not_include_a_link_to_the_first_page.yml
+++ b/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/does_not_include_a_link_to_the_first_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:06 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 2a23369f-ad5c-4ec8-b31b-2fcb7597c477
+      - f1d010d1-e2f1-43e3-919c-435521fd41ae
       X-Runtime:
-      - '0.030832'
+      - '0.027667'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,5 +78,5 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/includes_a_link_to_the_next_page.yml
+++ b/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/includes_a_link_to_the_next_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 69cd059d-702b-4cc0-8714-87a2b7eff622
+      - 1bbb99d5-4526-44d3-9477-b8e903e5212b
       X-Runtime:
-      - '0.029708'
+      - '0.037494'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,5 +78,5 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/includes_pagination.yml
+++ b/spec/cassettes/results_page_pagination/when_on_first_page_of_more_than_one_page_of_results/includes_pagination.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:06 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 168eafa0-b1ea-4454-8423-f03b7349f290
+      - 7480f589-998a-4d05-86d7-23f27f956d69
       X-Runtime:
-      - '0.045403'
+      - '0.028412'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,5 +78,5 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_last_page_of_results/does_not_include_a_link_to_the_last_page.yml
+++ b/spec/cassettes/results_page_pagination/when_on_last_page_of_results/does_not_include_a_link_to_the_last_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 8bc6069d-7ac8-4e71-b0b9-aeba9d9a2a99
+      - 4990fa27-8e9e-4bbb-a5b8-81edb0f4359a
       X-Runtime:
-      - '0.029115'
+      - '0.024637'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -79,5 +79,5 @@ http_interactions:
         403-4300","number_type":"voice","vanity_number":null},{"id":8,"department":null,"extension":null,"number":"650
         403-4303","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_last_page_of_results/does_not_include_a_link_to_the_next_page.yml
+++ b/spec/cassettes/results_page_pagination/when_on_last_page_of_results/does_not_include_a_link_to_the_next_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 2f6772b3-29f9-4218-8b85-74b33b2721c1
+      - 349c1a59-772c-4d1f-a13c-85c4a7c85d6f
       X-Runtime:
-      - '0.027067'
+      - '0.022245'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -79,5 +79,5 @@ http_interactions:
         403-4300","number_type":"voice","vanity_number":null},{"id":8,"department":null,"extension":null,"number":"650
         403-4303","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_on_last_page_of_results/includes_a_link_to_the_previous_page.yml
+++ b/spec/cassettes/results_page_pagination/when_on_last_page_of_results/includes_a_link_to_the_previous_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 7babaff7-e4f1-47f0-9b08-abdfff7e962e
+      - b0e33853-35d4-4501-9971-7ac740c72343
       X-Runtime:
-      - '0.029581'
+      - '0.030431'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -79,5 +79,5 @@ http_interactions:
         403-4300","number_type":"voice","vanity_number":null},{"id":8,"department":null,"extension":null,"number":"650
         403-4303","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/does_not_include_a_link_to_the_first_page.yml
+++ b/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/does_not_include_a_link_to_the_first_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 2e3d5a2a-3b87-4f70-911e-223dc77aafb5
+      - 57aa76a9-8615-45dd-84c0-69b2dd1afa02
       X-Runtime:
-      - '0.030309'
+      - '0.025265'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,7 +78,7 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=youth&page=2
@@ -119,15 +119,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 00d78700-02b5-490b-b310-4e62a6bd4b76
+      - f250e1a6-7fe0-4607-93e9-6fbcbdb8443a
       X-Runtime:
-      - '0.031064'
+      - '0.026449'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -151,5 +151,5 @@ http_interactions:
         720-0420","number_type":"voice","vanity_number":null},{"id":31,"department":null,"extension":null,"number":"408
         720-8075","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/does_not_include_a_link_to_the_last_page.yml
+++ b/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/does_not_include_a_link_to_the_last_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:06 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 7f97aa2c-5260-4fb6-a8f2-fa28f0570e55
+      - 5f8cbfaa-6737-49fd-acba-7075a0391a49
       X-Runtime:
-      - '0.028258'
+      - '0.023955'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,7 +78,7 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:06 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=youth&page=2
@@ -119,15 +119,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - bf494d06-b212-463e-940c-f0111c7c691a
+      - 1008d205-2701-49a4-9bfb-d3810774b6be
       X-Runtime:
-      - '0.031435'
+      - '0.023802'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -151,5 +151,5 @@ http_interactions:
         720-0420","number_type":"voice","vanity_number":null},{"id":31,"department":null,"extension":null,"number":"408
         720-8075","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/includes_a_link_to_the_next_page.yml
+++ b/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/includes_a_link_to_the_next_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - c467f991-bd60-47b7-89bc-f129ddf1a0e1
+      - 321c9f87-3d44-4150-ae4a-1568114eb2cd
       X-Runtime:
-      - '0.031394'
+      - '0.022494'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,7 +78,7 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=youth&page=2
@@ -119,15 +119,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:18 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 11343825-35ec-4fb8-96f9-c7814c5cdd05
+      - b8866296-3fc1-4e3f-b787-ee33fad5788b
       X-Runtime:
-      - '0.041090'
+      - '0.021299'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -151,5 +151,5 @@ http_interactions:
         720-0420","number_type":"voice","vanity_number":null},{"id":31,"department":null,"extension":null,"number":"408
         720-8075","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:18 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/includes_a_link_to_the_previous_page.yml
+++ b/spec/cassettes/results_page_pagination/when_past_first_page_of_results_but_not_last_page/includes_a_link_to_the_previous_page.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 7e2a4e0c-c1c8-4d9f-8f05-f673eb737641
+      - 397745a2-62c1-4e6a-bacd-cefb3b24446b
       X-Runtime:
-      - '0.027986'
+      - '0.048021'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -78,7 +78,7 @@ http_interactions:
         780-7077","number_type":"voice","vanity_number":null},{"id":24,"department":null,"extension":null,"number":"650
         780-7004","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=youth&page=2
@@ -119,15 +119,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:07 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 2595f7bb-3b4c-49cd-a1f4-6b5aa62fcf21
+      - 4f960010-abf8-496c-bcc6-e53632fb230b
       X-Runtime:
-      - '0.034871'
+      - '0.020836'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -151,5 +151,5 @@ http_interactions:
         720-0420","number_type":"voice","vanity_number":null},{"id":31,"department":null,"extension":null,"number":"408
         720-8075","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_are_no_results/displays_an_appropriate_search_summary.yml
+++ b/spec/cassettes/results_page_pagination/when_there_are_no_results/displays_an_appropriate_search_summary.yml
@@ -37,15 +37,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:20 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - b228ef4e-b6b3-4ca9-9b32-2de75206b300
+      - 49005d88-ba60-4de0-8f73-bce3df62e1c3
       X-Runtime:
-      - '0.015359'
+      - '0.012118'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:20 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_are_no_results/does_not_include_pagination.yml
+++ b/spec/cassettes/results_page_pagination/when_there_are_no_results/does_not_include_pagination.yml
@@ -37,15 +37,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:20 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 3f767310-7162-4379-b2bf-1bb0d3eb3f77
+      - b204c53f-3751-4ba3-b8f3-48c5a89f0ca7
       X-Runtime:
-      - '0.021075'
+      - '0.014676'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -56,5 +56,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:20 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_page_of_results_but_more_than_1_result/displays_an_appropriate_search_summary.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_page_of_results_but_more_than_1_result/displays_an_appropriate_search_summary.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - c139052b-bcc4-4052-866a-7ebe064ca3b0
+      - 7a8f8850-856c-47a1-a838-c41950e768d4
       X-Runtime:
-      - '0.043137'
+      - '0.023405'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -110,5 +110,5 @@ http_interactions:
         403-4300","number_type":"voice","vanity_number":null},{"id":8,"department":null,"extension":null,"number":"650
         403-4303","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_page_of_results_but_more_than_1_result/does_not_include_a_link_to_the_next_page.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_page_of_results_but_more_than_1_result/does_not_include_a_link_to_the_next_page.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - e77f122d-c37c-4cb8-8f7a-87e2bd548601
+      - 7622eafd-70fb-4c1e-9b62-07c0ae137b93
       X-Runtime:
-      - '0.056939'
+      - '0.036713'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -110,5 +110,5 @@ http_interactions:
         403-4300","number_type":"voice","vanity_number":null},{"id":8,"department":null,"extension":null,"number":"650
         403-4303","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_page_of_results_but_more_than_1_result/does_not_include_pagination.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_page_of_results_but_more_than_1_result/does_not_include_pagination.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:19 GMT
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - b4273c05-904b-4e78-b36c-4dc7cede5c80
+      - 4f74f08f-9c42-4b7b-8711-624134398fb0
       X-Runtime:
-      - '0.049833'
+      - '0.030377'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -110,5 +110,5 @@ http_interactions:
         403-4300","number_type":"voice","vanity_number":null},{"id":8,"department":null,"extension":null,"number":"650
         403-4303","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:19 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_result/displays_an_appropriate_search_summary.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_result/displays_an_appropriate_search_summary.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:17 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 545aea4e-65a6-4750-9cf6-1a5886f9b9ba
+      - 6a787b54-e0da-4ae6-b206-a174027e47d6
       X-Runtime:
-      - '0.028547'
+      - '0.023258'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:17 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/results_page_pagination/when_there_is_only_one_result/does_not_include_pagination.yml
+++ b/spec/cassettes/results_page_pagination/when_there_is_only_one_result/does_not_include_pagination.yml
@@ -35,15 +35,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:17 GMT
+      - Mon, 27 May 2019 21:20:05 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 742e075d-f001-4763-967a-f96b005e4b59
+      - f8634224-daad-46e4-9320-23490adbc518
       X-Runtime:
-      - '0.025920'
+      - '0.020115'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -80,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:17 GMT
+  recorded_at: Mon, 27 May 2019 21:20:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/search_results_map/none_of_the_results_have_coordinates/does_not_display_a_results_list_map.yml
+++ b/spec/cassettes/search_results_map/none_of_the_results_have_coordinates/does_not_display_a_results_list_map.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:24 GMT
+      - Mon, 27 May 2019 21:19:41 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 93bc3f88-2b1e-4eab-96b2-d61d1151308a
+      - 73bb8b81-24a7-463b-ae37-e114d0937c3c
       X-Runtime:
-      - '0.029947'
+      - '0.013987'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -57,5 +57,5 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:24 GMT
+  recorded_at: Mon, 27 May 2019 21:19:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/search_results_map/results_have_entries_that_have_coordinates/displays_a_results_list_map.yml
+++ b/spec/cassettes/search_results_map/results_have_entries_that_have_coordinates/displays_a_results_list_map.yml
@@ -35,23 +35,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Mar 2019 19:15:12 GMT
+      - Mon, 27 May 2019 21:19:41 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 6fcda67d-59b3-43a0-a2c3-8e7b933a3b5e
+      - 72809361-b2b7-4eaf-ace0-00730043c08d
       X-Runtime:
-      - '0.067266'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Age:
-      - '0'
+      - '0.032289'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -84,5 +80,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 19:15:12 GMT
+  recorded_at: Mon, 27 May 2019 21:19:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_a_location.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_a_location.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:51 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 3eaf2b5d-9552-40a4-a3e0-fea58f30dd0d
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:32 GMT
-      Age:
-      - '0'
+      - '0.025734'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:32 GMT
+  recorded_at: Mon, 27 May 2019 21:19:51 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=&utf8=%E2%9C%93
@@ -105,23 +101,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:32 GMT
+      - Mon, 27 May 2019 21:19:51 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - e060216f-82b8-4ad3-95f9-1aa025305581
+      - a9201e50-9045-4f0a-a851-0f0632552e63
       X-Runtime:
-      - '0.178439'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.048137'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -140,5 +132,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:32 GMT
+  recorded_at: Mon, 27 May 2019 21:19:51 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_an_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_an_agency_name.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:49 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 29fadef1-0d78-4379-a84a-28cf52a35b82
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:29 GMT
-      Age:
-      - '0'
+      - '0.019251'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:29 GMT
+  recorded_at: Mon, 27 May 2019 21:19:49 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=samaritan&utf8=%E2%9C%93
@@ -105,23 +101,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Mar 2019 14:31:29 GMT
+      - Mon, 27 May 2019 21:19:49 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 72d65103-eec8-41b5-9e8e-1c8c74f097c7
+      - 35d332b2-170e-42ae-9980-35ff65249deb
       X-Runtime:
-      - '0.211994'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.026299'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -140,5 +132,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:29 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_agency_name.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:51 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 37c826e6-bb62-4e87-bf51-58e4452cf090
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:30 GMT
-      Age:
-      - '0'
+      - '0.018623'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:30 GMT
+  recorded_at: Mon, 27 May 2019 21:19:51 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=&org_name=samaritan&utf8=%E2%9C%93
@@ -105,23 +101,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Mar 2019 14:31:30 GMT
+      - Mon, 27 May 2019 21:19:51 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - dd46eeff-8ec4-4ca4-826e-74a629e4b663
+      - 80ad93a7-9bff-4db7-b502-e6575b52dcd7
       X-Runtime:
-      - '0.294414'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.024388'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -140,5 +132,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:30 GMT
+  recorded_at: Mon, 27 May 2019 21:19:51 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_location.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_location.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:50 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - ee59580a-40a5-4ea1-975c-903cee8bc81f
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:31 GMT
-      Age:
-      - '0'
+      - '0.019017'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:31 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=94403&org_name=&utf8=%E2%9C%93
@@ -101,23 +97,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:32 GMT
+      - Mon, 27 May 2019 21:19:50 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f8ec2a9c-7c5f-4e31-9f4e-69d6117991fc
+      - 6311bc15-d511-4a8a-8ca6-b7c938e46dd6
       X-Runtime:
-      - '0.069329'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.045068'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -136,5 +128,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:32 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_both_location_and_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_both_location_and_agency_name.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:50 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - f5ac0b52-b593-4397-8540-4f3d7b55bd44
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:32 GMT
-      Age:
-      - '0'
+      - '0.017779'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:32 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=samaritan&utf8=%E2%9C%93
@@ -101,23 +97,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:32 GMT
+      - Mon, 27 May 2019 21:19:50 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - cdc42308-4304-4fca-8d13-6514d48527d8
+      - da5755ec-7fe7-4c70-88f8-bfc7719e9a98
       X-Runtime:
-      - '0.108280'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.049612'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -136,5 +128,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:32 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_keyword_location_and_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_keyword_location_and_agency_name.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:50 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 616af22f-5426-4aa2-802f-2d50b100f4bc
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:33 GMT
-      Age:
-      - '0'
+      - '0.022270'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:33 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=94403&org_name=samaritan&utf8=%E2%9C%93
@@ -101,23 +97,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:33 GMT
+      - Mon, 27 May 2019 21:19:50 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 148ed770-8e9d-460a-93ac-95ebf0259a9f
+      - 76f3bbdb-0f7c-4de1-89f3-47ae40c9adb3
       X-Runtime:
-      - '0.350759'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.051916'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -136,5 +128,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:33 GMT
+  recorded_at: Mon, 27 May 2019 21:19:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_a_search_parameter_has_no_value/is_not_included_in_the_page_title.yml
+++ b/spec/cassettes/searching_from_results_page/when_a_search_parameter_has_no_value/is_not_included_in_the_page_title.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - e9771e36-3896-4733-b292-627715dab22c
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:39 GMT
-      Age:
-      - '0'
+      - '0.020519'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:39 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403
@@ -104,23 +100,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:39 GMT
+      - Mon, 27 May 2019 21:19:54 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - ba85cc5c-b248-4af4-9e5f-e6e8f2fc2256
+      - 0aef6b61-729c-426c-907d-363a17b52b80
       X-Runtime:
-      - '0.037803'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.045516'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -139,5 +131,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:39 GMT
+  recorded_at: Mon, 27 May 2019 21:19:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_clicking_organization_link_in_results/displays_locations_that_belong_to_that_organization.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_organization_link_in_results/displays_locations_that_belong_to_that_organization.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:52 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 5567a679-6afe-4864-9f34-022eb6732d89
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
-      Age:
-      - '0'
+      - '0.017766'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:52 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=Samaritan%20House&location=&org_name=&utf8=%E2%9C%93
@@ -105,23 +101,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
+      - Mon, 27 May 2019 21:19:52 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - e6fb6054-5da9-435f-a157-56ff6f312f25
+      - a2ee3e80-acd6-4225-8d20-b19b0dbfb828
       X-Runtime:
-      - '0.024928'
-      X-Content-Digest:
-      - 1011b122da9208b10ff52af8ad0ba0f8c1d4b4db
-      Age:
-      - '0'
+      - '0.024967'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1853'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -143,7 +135,7 @@ http_interactions:
         839-1447","number_type":"voice","vanity_number":null},{"id":36,"department":null,"extension":null,"number":"650
         839-1457","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:52 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&org_name=Samaritan%20House
@@ -183,23 +175,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
+      - Mon, 27 May 2019 21:19:52 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - b1505ce9-2e9b-4b93-b7ff-bc48c5b35a95
+      - ba28f702-d347-48cf-a599-5749340bfc5f
       X-Runtime:
-      - '0.044234'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.028662'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -218,5 +206,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:52 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_agency/clears_the_contents_of_the_agency_field.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_agency/clears_the_contents_of_the_agency_field.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:00 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - c4e6c86b-ff14-4c8a-ade0-076314cb7308
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:32 GMT
-      Age:
-      - '0'
+      - '0.023571'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:32 GMT
+  recorded_at: Mon, 27 May 2019 21:20:00 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=samaritan&utf8=%E2%9C%93
@@ -104,24 +100,20 @@ http_interactions:
       - '2'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:00 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 72d65103-eec8-41b5-9e8e-1c8c74f097c7
+      - 9e0a7925-dc9a-4abc-b2e9-ed80dd57db5c
       X-Runtime:
-      - '0.211994'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Date:
-      - Tue, 19 Mar 2019 14:31:32 GMT
-      Age:
-      - '0'
+      - '0.027989'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -140,5 +132,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:32 GMT
+  recorded_at: Mon, 27 May 2019 21:20:00 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_keyword/clears_the_contents_of_the_keyword_field.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_keyword/clears_the_contents_of_the_keyword_field.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:58 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 6695a428-1c7a-4b72-9223-e6c19056ff41
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:30 GMT
-      Age:
-      - '0'
+      - '0.019766'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:30 GMT
+  recorded_at: Mon, 27 May 2019 21:19:58 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=&org_name=&utf8=%E2%9C%93
@@ -105,23 +101,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Mar 2019 14:31:31 GMT
+      - Mon, 27 May 2019 21:19:59 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 34873af1-bfe3-4abd-8125-342ac53fb26f
+      - e3829614-4852-4fad-8236-4be72d26755b
       X-Runtime:
-      - '0.030658'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Age:
-      - '0'
+      - '0.025268'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -140,5 +132,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:31 GMT
+  recorded_at: Mon, 27 May 2019 21:19:59 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_location/clears_the_contents_of_the_location_field.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_location/clears_the_contents_of_the_location_field.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:56 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 9c1b020b-bbfc-447e-844c-efebf6e34d9f
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:36 GMT
-      Age:
-      - '0'
+      - '0.027161'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:56 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=&utf8=%E2%9C%93
@@ -104,24 +100,20 @@ http_interactions:
       - '7'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:57 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - e060216f-82b8-4ad3-95f9-1aa025305581
+      - 2e6ad7eb-7347-49b4-b50a-0ce6f5513e2d
       X-Runtime:
-      - '0.178439'
-      X-Content-Digest:
-      - 4b11e1658669ee15d6d28a5b028611f854233dcc
-      Date:
-      - Mon, 18 Mar 2019 02:46:38 GMT
-      Age:
-      - '0'
+      - '0.046779'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '1651'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -140,5 +132,5 @@ http_interactions:
         578-0400","number_type":"voice","vanity_number":null},{"id":38,"department":null,"extension":null,"number":"650
         578-0440","number_type":"fax","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:38 GMT
+  recorded_at: Mon, 27 May 2019 21:19:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_multiple_search_parameters_have_values/they_are_all_included_in_the_page_title.yml
+++ b/spec/cassettes/searching_from_results_page/when_multiple_search_parameters_have_values/they_are_all_included_in_the_page_title.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:01 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 0e03acb3-a04e-4e51-a83d-2a80145707d2
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
-      Age:
-      - '0'
+      - '0.036756'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:20:01 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=foo&location=94403
@@ -103,28 +99,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 8915315c-528f-4ea3-9e1c-b29ebc9d024a
+      - dc9956d5-5339-4e4e-a2e1-e8b7d14e784f
       X-Runtime:
-      - '0.019388'
-      X-Content-Digest:
-      - 97d170e1550eee4afc0af065b78cda302a97674c
-      Age:
-      - '0'
+      - '0.102833'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '2'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_accreditation_list.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_accreditation_list.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:54 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - dbbe5d6f-cb5a-42a3-89c7-2f746a196b7f
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:39 GMT
-      Age:
-      - '0'
+      - '0.049607'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:39 GMT
+  recorded_at: Mon, 27 May 2019 21:19:54 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - d0064889-dddd-405d-9692-f4fc7ef5d169
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:39 GMT
-      Age:
-      - '0'
+      - '0.037461'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:39 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_alternative_name.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_alternative_name.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:56 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - a9f0cd19-4c26-450b-aec5-10e104c54a7c
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
-      Age:
-      - '0'
+      - '0.020516'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:37 GMT
+  recorded_at: Mon, 27 May 2019 21:19:56 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:56 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - '06257842-e2f1-4150-93bb-2f09735f2810'
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:37 GMT
-      Age:
-      - '0'
+      - '0.021663'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:37 GMT
+  recorded_at: Mon, 27 May 2019 21:19:56 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_email_address.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_email_address.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:56 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 1fd94a89-3168-4d13-91fe-3dd726d3a731
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:37 GMT
-      Age:
-      - '0'
+      - '0.030501'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:37 GMT
+  recorded_at: Mon, 27 May 2019 21:19:56 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:56 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - b3935350-da7d-4a86-ad71-5b51d52cd0ab
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:37 GMT
-      Age:
-      - '0'
+      - '0.025301'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:38 GMT
+  recorded_at: Mon, 27 May 2019 21:19:56 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_incorporation_date.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_incorporation_date.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 6973daf3-5239-427f-9b03-468a74e532cc
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
-      Age:
-      - '0'
+      - '0.030814'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - 8b993a77-241e-4998-b5ab-1ddc397593c5
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
-      Age:
-      - '0'
+      - '0.059193'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_licenses_list.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_licenses_list.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:54 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 5882bf89-22d5-47de-963f-7bbe0dde2298
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
-      Age:
-      - '0'
+      - '0.021227'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:54 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -101,23 +97,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
+      - Mon, 27 May 2019 21:19:54 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - 5603649c-cb14-4487-b937-b773f8afbd9f
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Age:
-      - '0'
+      - '0.022889'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_name_in_detail_box.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_name_in_detail_box.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - bf0a1a1d-5a36-42fa-9638-5a571b7999d6
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:38 GMT
-      Age:
-      - '0'
+      - '0.024213'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:38 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - d0217e00-b522-4c06-ae39-37d4af913388
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:38 GMT
-      Age:
-      - '0'
+      - '0.027061'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:38 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_website_address.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_website_address.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 9307d27e-df96-496e-96ca-b8061cb2bc3a
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
-      Age:
-      - '0'
+      - '0.022186'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:55 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 884c96cf-0608-44f2-9415-b61bab177691
+      - 9c02d843-6e20-4fb0-9d3a-b27348145872
       X-Runtime:
-      - '0.044908'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:36 GMT
-      Age:
-      - '0'
+      - '0.026177'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:36 GMT
+  recorded_at: Mon, 27 May 2019 21:19:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_contains_invalid_parameters/displays_a_helpful_error_message.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_contains_invalid_parameters/displays_a_helpful_error_message.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:51 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - abe2aa71-d84e-4408-8361-be98440f760f
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
-      Age:
-      - '0'
+      - '0.018876'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:51 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&location=94403&radius=foo
@@ -101,13 +97,13 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 1f1ac184-6479-491a-a5c9-786b84d9004c
+      - ebc0b4fb-cfff-465d-9f76-832a27a7a73d
       X-Runtime:
-      - '0.005322'
+      - '0.022726'
       Date:
-      - Mon, 18 Mar 2019 02:46:40 GMT
+      - Mon, 27 May 2019 21:19:52 GMT
       X-Rack-Cache:
-      - miss
+      - pass
       Transfer-Encoding:
       - chunked
       Via:
@@ -117,5 +113,5 @@ http_interactions:
       string: '{"status":400,"error":"Argument Error","description":"Radius must be
         a Float between 0.1 and 50."}'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:52 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/displays_a_helpful_error_message.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/displays_a_helpful_error_message.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - f8108110-36b3-4ef5-baa5-23c28536d826
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:34 GMT
-      Age:
-      - '0'
+      - '0.018774'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:34 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
@@ -103,29 +99,25 @@ http_interactions:
       - '0'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 99d52738-2540-4c26-a9a4-f61940d64fea
+      - 3bde3d72-3355-4bfa-a8ca-810820497b9d
       X-Runtime:
-      - '0.473353'
-      X-Content-Digest:
-      - 97d170e1550eee4afc0af065b78cda302a97674c
-      Date:
-      - Mon, 18 Mar 2019 02:46:34 GMT
-      Age:
-      - '0'
+      - '0.041912'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:34 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/does_not_include_the_map_canvas.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/does_not_include_the_map_canvas.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 180ffed3-853d-4473-a5f3-b5fedfac78b5
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:40 GMT
-      Age:
-      - '0'
+      - '0.020335'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
@@ -103,29 +99,25 @@ http_interactions:
       - '0'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 99d52738-2540-4c26-a9a4-f61940d64fea
+      - 9d33f8e6-cb83-4eac-a63d-f5e2f87dd172
       X-Runtime:
-      - '0.473353'
-      X-Content-Digest:
-      - 97d170e1550eee4afc0af065b78cda302a97674c
-      Date:
-      - Tue, 19 Mar 2019 14:31:40 GMT
-      Age:
-      - '0'
+      - '0.035818'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_homepage_links.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_homepage_links.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:52 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 86cc3ac9-caac-4559-87be-a5197d4c6ed5
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:39 GMT
-      Age:
-      - '0'
+      - '0.020239'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:52 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
@@ -103,29 +99,25 @@ http_interactions:
       - '0'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:52 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 99d52738-2540-4c26-a9a4-f61940d64fea
+      - f29263e5-4c22-43f3-8610-3c937d01fb43
       X-Runtime:
-      - '0.473353'
-      X-Content-Digest:
-      - 97d170e1550eee4afc0af065b78cda302a97674c
-      Date:
-      - Tue, 19 Mar 2019 14:31:40 GMT
-      Age:
-      - '0'
+      - '0.036002'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:40 GMT
+  recorded_at: Mon, 27 May 2019 21:19:52 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_no-results_selector.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_no-results_selector.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 45bfb227-defd-4f3f-a720-aaa4835ce05e
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Mon, 18 Mar 2019 02:46:33 GMT
-      Age:
-      - '0'
+      - '0.020290'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:33 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
@@ -104,28 +100,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 18 Mar 2019 02:46:34 GMT
+      - Mon, 27 May 2019 21:19:53 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 99d52738-2540-4c26-a9a4-f61940d64fea
+      - 304e9e87-37db-41c5-b071-512c8cb8f274
       X-Runtime:
-      - '0.473353'
-      X-Content-Digest:
-      - 97d170e1550eee4afc0af065b78cda302a97674c
-      Age:
-      - '0'
+      - '0.035869'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '2'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
       string: "[]"
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 02:46:34 GMT
+  recorded_at: Mon, 27 May 2019 21:19:53 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_extension.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_extension.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 36dbf8e5-5849-49c4-9b7d-7fc85bcb3672
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:33 GMT
-      Age:
-      - '0'
+      - '0.036386'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:33 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - c8559366-bdca-46a5-856e-235f846301b3
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:33 GMT
-      Age:
-      - '0'
+      - '0.027742'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:33 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_number.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_number.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - a4d94e65-7224-40d8-9dff-a94b81457029
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:35 GMT
-      Age:
-      - '0'
+      - '0.019022'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:35 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - ddd526c9-dff1-47a0-b192-6b6980ee214f
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:35 GMT
-      Age:
-      - '0'
+      - '0.018144'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:35 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_physical_address.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_physical_address.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - '08296b69-9acd-4d43-a55a-e84825a6fe9d'
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:33 GMT
-      Age:
-      - '0'
+      - '0.019355'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:33 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -101,23 +97,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Mar 2019 14:31:33 GMT
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - 44cad210-05c7-4535-9d32-68eb21717af2
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Age:
-      - '0'
+      - '0.018732'
       X-Rack-Cache:
-      - miss, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:33 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_short_description.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_short_description.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 1bb3934b-316d-458f-963b-735db36e5a36
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:33 GMT
-      Age:
-      - '0'
+      - '0.023754'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:33 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - fba41296-b946-43e6-b7fe-b0581bd02de7
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:33 GMT
-      Age:
-      - '0'
+      - '0.020042'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_agency_as_a_link.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_agency_as_a_link.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - ca9bb8cc-6927-4b17-b4c2-a8fe014a8aa8
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:34 GMT
-      Age:
-      - '0'
+      - '0.021076'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - ac010f4d-e736-4dee-a9ce-6f3b4087b1fb
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:34 GMT
-      Age:
-      - '0'
+      - '0.021766'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_location_as_a_link.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_location_as_a_link.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - d22c0876-843a-4789-899e-08cd08b0e527
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:34 GMT
-      Age:
-      - '0'
+      - '0.035285'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - 1ff366b1-f32a-4a33-9038-fea7ce1add38
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:34 GMT
-      Age:
-      - '0'
+      - '0.038625'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_number_of_results.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_number_of_results.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - c9c4fc87-f863-4a3e-968a-9651290a2667
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:35 GMT
-      Age:
-      - '0'
+      - '0.021936'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:35 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:03 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - c402e78d-21e0-4012-aba9-4e8ff8df544d
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:35 GMT
-      Age:
-      - '0'
+      - '0.019796'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:35 GMT
+  recorded_at: Mon, 27 May 2019 21:20:03 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/includes_the_results_info_in_the_page_title.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/includes_the_results_info_in_the_page_title.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 2a5446d3-69a5-4be0-9f9d-6561337e0934
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:35 GMT
-      Age:
-      - '0'
+      - '0.021970'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:35 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:04 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - b79a1e2b-d143-4be0-b157-221fca8fe146
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:35 GMT
-      Age:
-      - '0'
+      - '0.019963'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:35 GMT
+  recorded_at: Mon, 27 May 2019 21:20:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/populates_the_keyword_field_with_the_search_term.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/populates_the_keyword_field_with_the_search_term.yml
@@ -37,24 +37,20 @@ http_interactions:
       - '22'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 9dffc21f-8101-4bd2-b28f-2a93f28fa0cb
+      - 7b874a5a-588a-4e3b-bbb4-e57650ddedfa
       X-Runtime:
-      - '0.228839'
-      X-Content-Digest:
-      - e98ccdd286c40ad0e365d3852e5cbff9d1952d8e
-      Date:
-      - Tue, 19 Mar 2019 14:31:34 GMT
-      Age:
-      - '0'
+      - '0.031286'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '811'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -65,7 +61,7 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 - request:
     method: get
     uri: http://ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=example&location=&org_name=&utf8=%E2%9C%93
@@ -100,24 +96,20 @@ http_interactions:
       - '1'
       Content-Type:
       - application/json; charset=utf-8
+      Date:
+      - Mon, 27 May 2019 21:20:02 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - f7b9f9b0-96c6-44ea-a3e2-07a883d79c28
+      - '09f066b7-4817-4cfb-8dc7-7632faa3def3'
       X-Runtime:
-      - '0.052597'
-      X-Content-Digest:
-      - 5930dbebe575730df3dec5e022b71aa11f71c205
-      Date:
-      - Tue, 19 Mar 2019 14:31:34 GMT
-      Age:
-      - '0'
+      - '0.021244'
       X-Rack-Cache:
-      - stale, valid, store
-      Content-Length:
-      - '2849'
+      - pass
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
@@ -150,5 +142,5 @@ http_interactions:
         372-6200","number_type":"hotline","vanity_number":null},{"id":46,"department":"Rental
         Assistance","extension":"202","number":"650 372-6200","number_type":"tty","vanity_number":null}]}]'
     http_version: 
-  recorded_at: Tue, 19 Mar 2019 14:31:34 GMT
+  recorded_at: Mon, 27 May 2019 21:20:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/tabindex_for_search_results/gives_the_agency_field_a_tabindex_of_3.yml
+++ b/spec/cassettes/tabindex_for_search_results/gives_the_agency_field_a_tabindex_of_3.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:17 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - edb25445-4d37-44dd-911e-087976bca895
+      - 6dc43d6d-4d5a-4cce-b2a0-361123643d8c
       X-Runtime:
-      - '0.026222'
+      - '0.019531'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:17 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/tabindex_for_search_results/gives_the_keyword_field_a_tabindex_of_1.yml
+++ b/spec/cassettes/tabindex_for_search_results/gives_the_keyword_field_a_tabindex_of_1.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:17 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - d267ca1b-cfaa-45c4-ab94-f96c919718f3
+      - 3d7f4b4b-0ce4-4a01-9a5e-568d3e3d6a76
       X-Runtime:
-      - '0.026411'
+      - '0.021071'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:17 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/tabindex_for_search_results/gives_the_location_field_a_tabindex_of_2.yml
+++ b/spec/cassettes/tabindex_for_search_results/gives_the_location_field_a_tabindex_of_2.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:17 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - c91ab04c-8bf5-41bb-8424-8df35b1c8f07
+      - ed86d2b8-c47d-4fa9-bd18-7fbe3da925f2
       X-Runtime:
-      - '0.032231'
+      - '0.020357'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:17 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/tabindex_for_search_results/only_has_one_tabindex_of_1_2_and_3.yml
+++ b/spec/cassettes/tabindex_for_search_results/only_has_one_tabindex_of_1_2_and_3.yml
@@ -38,15 +38,15 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sun, 17 Mar 2019 17:39:17 GMT
+      - Mon, 27 May 2019 21:20:11 GMT
       Cache-Control:
       - max-age=0, public
       Vary:
       - Origin
       X-Request-Id:
-      - 5c70a87f-d25a-4a35-badc-6b0aedad25a0
+      - 883439d6-c8fc-40e1-a0ec-71f6c1d4dfbb
       X-Runtime:
-      - '0.026283'
+      - '0.017585'
       X-Rack-Cache:
       - pass
       Transfer-Encoding:
@@ -61,5 +61,5 @@ http_interactions:
         organization created for testing purposes.","email":null,"funding_sources":[],"licenses":[],"name":"Fake
         Org","website":null,"slug":"fake-org","url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org","locations_url":"http://ohana-api-test.herokuapp.com/api/organizations/fake-org/locations"},"phones":[]}]'
     http_version: 
-  recorded_at: Sun, 17 Mar 2019 17:39:17 GMT
+  recorded_at: Mon, 27 May 2019 21:20:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/features/general/translate_spec.rb
+++ b/spec/features/general/translate_spec.rb
@@ -1,32 +1,11 @@
 require 'rails_helper'
 
 feature 'page translation', :js do
-  background do
-    page.driver.remove_cookie('googtrans')
-  end
-
-  context 'translation cookie is set to Spanish' do
-    it 'displays Spanish-language contents' do
-      page.driver.
-        set_cookie('googtrans', '/en/es', path: '/', domain: 'lvh.me')
-      page.driver.
-        set_cookie('googtrans', '/en/es', path: '/', domain: '.lvh.me')
-
-      visit("http://www.lvh.me:#{Capybara.server_port}/")
-      within('#language-box') do
-        all_links = all('a')
-        expect(all_links).not_to include 'Español'
-      end
-      expect(page).to have_content('Necesito')
-    end
-  end
-
   context 'homepage is translated' do
     it 'displays translated contents' do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
       find_link('Español').click
       delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/es')
       within('#language-box') do
         all_links = all('a')
         expect(all_links).not_to include 'Español'
@@ -51,16 +30,12 @@ feature 'page translation', :js do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
       find_link('Español').click
       delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/es')
       expect(page).to have_content('Necesito')
       find_link('Tagalog').click
       delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/tl')
       expect(page).to have_content('Kailangan ko')
       find_link('English').click
       expect(page).to have_content('I need')
-      delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/en')
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,17 +1,23 @@
-require 'capybara/poltergeist'
+require 'webdrivers/chromedriver'
 
 Capybara.configure do |config|
-  config.javascript_driver = :poltergeist
-  config.default_max_wait_time = 30
+  config.default_max_wait_time = 10
   config.always_include_port = true
 end
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-    app, js_errors: false, phantomjs_options: ['--ignore-ssl-errors=yes']
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless disable-gpu] }
   )
+
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities
 end
+Capybara.javascript_driver = :headless_chrome
 
 Capybara.add_selector(:rel) do
   xpath { |rel| ".//a[@rel='#{rel}']" }
 end
+
+Webdrivers.cache_time = 86_400

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,7 +3,7 @@ require 'vcr'
 
 VCR.configure do |config|
   config.configure_rspec_metadata!
-  config.ignore_hosts '127.0.0.1', 'localhost'
+  config.ignore_hosts '127.0.0.1', 'localhost', 'chromedriver.storage.googleapis.com'
   config.default_cassette_options = { record: :once }
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock


### PR DESCRIPTION
**Why**: PhantomJS has been discontinued and is no longer guaranteed
to work on recent versions of macOS. Webdrivers is the latest
recommended gem that supports various drivers for Selenium, such as
the popular chromedriver.